### PR TITLE
feat: add ability to refresh feed and trigger feed poll on create

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,7 +241,10 @@ dependencies = [
  "diesel",
  "diesel-async",
  "serde",
+ "tokio",
+ "tracing",
  "utils",
+ "wyrm-rss",
 ]
 
 [[package]]
@@ -272,6 +275,7 @@ name = "api_utils"
 version = "0.3.0"
 dependencies = [
  "database",
+ "tokio",
  "utils",
  "wyrm-rss",
 ]

--- a/api/api/Cargo.toml
+++ b/api/api/Cargo.toml
@@ -8,6 +8,8 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+tokio = { workspace = true }
+tracing = { workspace = true }
 actix-web = { workspace = true }
 serde = { workspace = true }
 chrono = { workspace = true }
@@ -16,3 +18,4 @@ diesel-async = { workspace = true }
 api_utils = { path = "../utils" }
 utils = { path = "../../utils" }
 database = { path = "../../database" }
+wyrm-rss = { path = "../../rss" }

--- a/api/api/src/feeds.rs
+++ b/api/api/src/feeds.rs
@@ -1,7 +1,14 @@
-use actix_web::web::{Data, Json, Path};
+use std::time::Duration;
+
+use actix_web::{
+    HttpResponse,
+    web::{Data, Json, Path},
+};
 use api_utils::context::WyrmContext;
 use database::models::feed::Feed;
-use utils::result::WyrmResult;
+use tokio::sync::mpsc::error::TrySendError;
+use utils::{error::WyrmError, result::WyrmResult};
+use wyrm_rss::worker::FeedCommand;
 
 pub async fn get(path: Path<i32>, ctx: Data<WyrmContext>) -> WyrmResult<Json<Feed>> {
     let feed = Feed::get(&ctx.db_pool, path.into_inner()).await?;
@@ -11,4 +18,23 @@ pub async fn get(path: Path<i32>, ctx: Data<WyrmContext>) -> WyrmResult<Json<Fee
 pub async fn list(ctx: Data<WyrmContext>) -> WyrmResult<Json<Vec<Feed>>> {
     let feeds = Feed::get_all(&ctx.db_pool).await?;
     Ok(Json(feeds))
+}
+
+pub async fn poll(ctx: Data<WyrmContext>) -> WyrmResult<HttpResponse> {
+    // channel through which worker signals completion
+    let (tx, rx) = tokio::sync::oneshot::channel();
+
+    match ctx.worker_tx.try_send(FeedCommand::Fetch(tx)) {
+        Err(TrySendError::Full(_)) => return Ok(HttpResponse::Accepted().finish()),
+        Err(TrySendError::Closed(_)) => {
+            tracing::error!("feed worker channel closed");
+            return Err(WyrmError::WorkerError);
+        }
+        Ok(_) => {}
+    }
+
+    match tokio::time::timeout(Duration::from_secs(30), rx).await {
+        Ok(_) => Ok(HttpResponse::Ok().finish()),
+        Err(_) => Ok(HttpResponse::GatewayTimeout().finish()),
+    }
 }

--- a/api/routes/src/feeds.rs
+++ b/api/routes/src/feeds.rs
@@ -7,6 +7,7 @@ pub fn config(cfg: &mut web::ServiceConfig) {
         web::scope("/feeds")
             .route("", web::get().to(feeds::list))
             .route("", web::post().to(crud_feeds::create))
+            .route("/poll", web::post().to(feeds::poll))
             .route("/{feed_id}", web::get().to(feeds::get))
             .route("/{feed_id}", web::patch().to(crud_feeds::update))
             .route("/{feed_id}", web::delete().to(crud_feeds::delete)),

--- a/api/utils/Cargo.toml
+++ b/api/utils/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+tokio = { workspace = true }
 utils = { path = "../../utils" }
 database = { path = "../../database" }
 wyrm-rss = { path = "../../rss" }

--- a/api/utils/src/context.rs
+++ b/api/utils/src/context.rs
@@ -1,10 +1,12 @@
 use database::DatabasePool;
+use tokio::sync::mpsc::Sender;
 use utils::settings::WyrmSettings;
-use wyrm_rss::http::HttpClient;
+use wyrm_rss::{http::HttpClient, worker::FeedCommand};
 
 #[derive(Clone)]
 pub struct WyrmContext {
     pub db_pool: DatabasePool,
     pub settings: WyrmSettings,
     pub http: HttpClient,
+    pub worker_tx: Sender<FeedCommand>,
 }

--- a/rss/src/worker.rs
+++ b/rss/src/worker.rs
@@ -10,10 +10,16 @@ use database::{
     },
 };
 use futures::future::join_all;
+use tokio::sync::mpsc::Receiver;
 use tracing::{error, info};
 use utils::result::WyrmResult;
 
-const INTERVAL: Duration = Duration::from_secs(30);
+#[derive(Debug)]
+pub enum FeedCommand {
+    Fetch(tokio::sync::oneshot::Sender<()>),
+}
+
+const INTERVAL: Duration = Duration::from_secs(900); // 15 min
 
 /// Background worker responsible for polling RSS feeds on a scheduled interval.
 ///
@@ -35,14 +41,27 @@ impl FeedWorker {
 
     /// Starts the feed polling loop.
     ///
-    /// Runs indefinitely, polling due feeds every [`INTERVAL`] seconds.
-    /// Errors are logged but do not stop the worker.
-    pub async fn run(&mut self) {
+    /// Runs indefinitely, polling due feeds every [`INTERVAL`] seconds or when a
+    /// [`FeedCommand::Fetch`] is received. Errors are logged but do not stop the worker.
+    pub async fn run(&mut self, mut rx: Receiver<FeedCommand>) {
         let mut interval = tokio::time::interval(INTERVAL);
         loop {
-            interval.tick().await;
-            if let Err(e) = self.poll_feeds().await {
-                error!("Feed worker error: {e}");
+            tokio::select! {
+                _ = interval.tick() => {
+                    if let Err(e) = self.poll_feeds().await {
+                        error!("Feed worker error: {e}");
+                    }
+                }
+                Some(cmd) = rx.recv() => {
+                    match cmd {
+                        FeedCommand::Fetch(reply) => {
+                            if let Err(e) = self.poll_feeds().await {
+                                error!("Feed worker error: {e}");
+                            }
+                            let _ = reply.send(());
+                        }
+                    }
+                }
             }
         }
     }
@@ -52,6 +71,8 @@ impl FeedWorker {
         let feeds = Feed::get_all(&self.db_pool).await?;
 
         let due_feeds: Vec<Feed> = feeds.into_iter().filter(|f| f.is_due()).collect();
+
+        info!("Processing {} due feeds", due_feeds.len());
 
         let tasks: Vec<_> = due_feeds
             .into_iter()

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -6,7 +6,7 @@ use utils::error::{DatabaseError, HttpServerError};
 use utils::result::WyrmResult;
 use utils::settings::WyrmSettings;
 use wyrm_rss::http::HttpClient;
-use wyrm_rss::worker::FeedWorker;
+use wyrm_rss::worker::{FeedCommand, FeedWorker};
 
 pub async fn start_server() -> WyrmResult<()> {
     info!("Loading settings");
@@ -24,15 +24,18 @@ pub async fn start_server() -> WyrmResult<()> {
     info!("Building http client");
     let http = HttpClient::builder(&settings).build()?;
 
+    let (tx, rx) = tokio::sync::mpsc::channel::<FeedCommand>(1);
+
     let ctx = web::Data::new(WyrmContext {
         db_pool: db_pool.clone(),
         settings: settings.clone(),
         http: http.clone(),
+        worker_tx: tx,
     });
 
     tokio::spawn(async move {
         let mut rss_worker = FeedWorker::new(db_pool, http);
-        rss_worker.run().await;
+        rss_worker.run(rx).await;
     });
 
     info!("Starting up HTTP server");

--- a/utils/src/error.rs
+++ b/utils/src/error.rs
@@ -48,6 +48,8 @@ pub enum WyrmError {
     HttpClient(#[from] HttpClientError),
     #[error("rss parse feed error: {0}")]
     ParseFeedError(#[from] feed_rs::parser::ParseFeedError),
+    #[error("rss worker error")]
+    WorkerError,
 }
 
 impl From<reqwest::Error> for WyrmError {

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -432,9 +432,44 @@
 /* ── Post list ───────────────────────────────────────────────── */
 
 .posts-toolbar {
+  display: flex;
+  gap: 8px;
+  align-items: center;
   padding: 12px 16px;
   border-bottom: 1px solid var(--border);
   flex-shrink: 0;
+}
+
+.posts-refresh-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  padding: 6px;
+  background: var(--code-bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-h);
+  cursor: pointer;
+  font-size: 16px;
+
+  &:hover:not(:disabled) {
+    background: var(--hover-bg);
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.spinning {
+  animation: spin 0.6s linear infinite;
 }
 
 .posts-search {

--- a/web/src/api/feeds.ts
+++ b/web/src/api/feeds.ts
@@ -1,7 +1,7 @@
 import type { Feed } from "../types/Feed";
 import type { CreateFeed } from "../types/CreateFeed";
 import type { UpdateFeed } from "../types/UpdateFeed";
-import { ENDPOINTS, json } from "../utils/api";
+import { ENDPOINTS, json, noContent } from "../utils/api";
 
 export const getFeeds = (): Promise<Feed[]> =>
   fetch(ENDPOINTS.feeds.list()).then<Feed[]>(json);
@@ -25,3 +25,6 @@ export const updateFeed = (id: number, body: UpdateFeed): Promise<Feed> =>
 
 export const deleteFeed = (id: number): Promise<Feed> =>
   fetch(ENDPOINTS.feeds.delete(id), { method: "DELETE" }).then<Feed>(json);
+
+export const pollFeeds = (): Promise<void> =>
+  fetch(ENDPOINTS.feeds.poll(), { method: "POST" }).then(noContent);

--- a/web/src/components/PostList.tsx
+++ b/web/src/components/PostList.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react";
 import { useLocation, useOutletContext, useParams } from "react-router-dom";
+import { TbRefresh } from "react-icons/tb";
 import { useFavoritePosts, usePosts } from "../hooks/usePosts";
-import { useFeeds } from "../hooks/useFeeds";
+import { useFeeds, usePollFeeds } from "../hooks/useFeeds";
 import { PostItem } from "./PostItem";
 import type { Post } from "../types/Post";
 import type { ReaderOutletContext } from "../pages/ReaderPage";
@@ -44,11 +45,17 @@ export function PostList() {
   const [search, setSearch] = useState("");
   const { data: feeds } = useFeeds();
   const feedIdNum = feedId ? Number(feedId) : undefined;
+  const pollMutation = usePollFeeds();
   const postsQuery = usePosts(feedIdNum);
   const favoritesQuery = useFavoritePosts();
-  const { data, isLoading, hasNextPage, fetchNextPage, isFetchingNextPage } = isFavorites
-    ? favoritesQuery
-    : postsQuery;
+  const {
+    data,
+    isLoading,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage,
+    isRefetching
+  } = isFavorites ? favoritesQuery : postsQuery;
   const feedMap = feeds ? new Map(feeds.map((f) => [f.id, f.title])) : new Map<number, string>();
 
   useEffect(() => {
@@ -72,6 +79,14 @@ export function PostList() {
           value={search}
           onChange={(e) => setSearch(e.target.value)}
         />
+        <button
+          className="posts-refresh-btn"
+          onClick={() => pollMutation.mutate()}
+          disabled={pollMutation.isPending || isRefetching || isLoading}
+          title="Refresh"
+        >
+          <TbRefresh className={pollMutation.isPending || isRefetching ? "spinning" : ""} />
+        </button>
       </div>
       <div className="pane-scroll">
         {isLoading && <div className="pane-empty">Loading…</div>}

--- a/web/src/hooks/useFeeds.ts
+++ b/web/src/hooks/useFeeds.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { createFeed, deleteFeed, getFeeds, updateFeed } from "../api/feeds";
+import { createFeed, deleteFeed, getFeeds, pollFeeds, updateFeed } from "../api/feeds";
+import { postKeys } from "./usePosts";
 import type { CreateFeed } from "../types/CreateFeed";
 import type { UpdateFeed } from "../types/UpdateFeed";
 
@@ -15,7 +16,11 @@ export function useCreateFeed() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (body: CreateFeed) => createFeed(body),
-    onSuccess: () => qc.invalidateQueries({ queryKey: feedKeys.all }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: feedKeys.all });
+      const refresh = () => qc.invalidateQueries({ queryKey: postKeys.all });
+      pollFeeds().then(refresh).catch(refresh);
+    },
   });
 }
 
@@ -33,5 +38,16 @@ export function useDeleteFeed() {
   return useMutation({
     mutationFn: (id: number) => deleteFeed(id),
     onSuccess: () => qc.invalidateQueries({ queryKey: feedKeys.all }),
+  });
+}
+
+export function usePollFeeds() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: pollFeeds,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: feedKeys.all });
+      qc.invalidateQueries({ queryKey: postKeys.all });
+    },
   });
 }

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -14,6 +14,7 @@ export const ENDPOINTS = {
     create: () => `${BASE}/feeds`,
     update: (id: number) => `${BASE}/feeds/${id}`,
     delete: (id: number) => `${BASE}/feeds/${id}`,
+    poll: () => `${BASE}/feeds/poll`,
   },
   posts: {
     list: (cursor?: Cursor) => `${BASE}/posts${cursorParams(cursor)}`,
@@ -27,4 +28,8 @@ export const ENDPOINTS = {
 export async function json<T>(res: Response): Promise<T> {
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
   return res.json();
+}
+
+export async function noContent(res: Response): Promise<void> {
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
 }


### PR DESCRIPTION
Adding a refresh button at the top of the UI to allow user the ability to trigger a feed refresh.

For that, a new API is introduced: `POST /feeds/poll`, which sends a message through a tokio channel to the RSS feed worker for a poll. 

Adding a new feed also now triggers a poll automatically so that the UI is immediately updated with the feed posts.

As a result of these changes, I'm increasing the worker background polling interval to 15 minutes.