### PR TITLE
fix: pnpm lint

### DIFF
--- a/web/src/components/PostReader.tsx
+++ b/web/src/components/PostReader.tsx
@@ -42,7 +42,7 @@ export function PostReader({ postId, onClose, width }: Props) {
     if (post && !post.is_read) {
       updatePost({ id: post.id, is_read: true, is_favorite: null });
     }
-  }, [post?.id]);
+  }, [post, updatePost]);
 
   if (!postId) return null;
 


### PR DESCRIPTION
```
45:6  warning  React Hook useEffect has missing dependencies: 'post' and 'updatePost'. 
Either include them or remove the dependency array  react-hooks/exhaustive-deps
```