### PR TITLE
feat: appearance settings with theme, accent, and font size

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -45,7 +45,7 @@
   align-items: center;
   justify-content: center;
   color: var(--text);
-  font-size: 14px;
+  font-size: 0.78rem;
   opacity: 0.5;
   padding: 40px 0;
 }
@@ -79,14 +79,14 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 13px;
+  font-size: 0.72rem;
   font-weight: 700;
   color: var(--accent);
   flex-shrink: 0;
 }
 
 .sidebar-name {
-  font-size: 14px;
+  font-size: 0.78rem;
   font-weight: 600;
   color: var(--text-h);
 }
@@ -135,7 +135,7 @@
   background: none;
   border: none;
   cursor: pointer;
-  font-size: 15px;
+  font-size: 0.83rem;
   line-height: 1;
   padding: 3px 5px;
   border-radius: 4px;
@@ -161,7 +161,7 @@
 .sidebar-nav-item {
   display: block;
   padding: 7px 10px;
-  font-size: 14px;
+  font-size: 0.78rem;
   color: var(--text);
   text-decoration: none;
   border-radius: 5px;
@@ -193,7 +193,7 @@
   align-items: center;
   justify-content: space-between;
   padding: 10px 12px 6px;
-  font-size: 11px;
+  font-size: 0.61rem;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.8px;
@@ -202,7 +202,7 @@
 }
 
 .sidebar-feeds-search {
-  font-size: 12px;
+  font-size: 0.67rem;
   padding: 3px 7px;
   background: var(--code-bg);
   border: 1px solid var(--border);
@@ -232,7 +232,7 @@
   padding: 9px 12px;
   text-decoration: none;
   color: var(--text);
-  font-size: 13px;
+  font-size: 0.72rem;
   border-bottom: 1px solid var(--border);
   cursor: pointer;
 
@@ -273,7 +273,7 @@
 .feed-item-tag {
   --tag-color: var(--text);
   flex-shrink: 0;
-  font-size: 10px;
+  font-size: 0.56rem;
   font-weight: 500;
   padding: 1px 5px;
   border-radius: 3px;
@@ -292,7 +292,7 @@
   border: none;
   cursor: pointer;
   color: var(--text);
-  font-size: 12px;
+  font-size: 0.67rem;
   line-height: 1;
   padding: 0 2px;
   flex-shrink: 0;
@@ -333,7 +333,7 @@
   border: none;
   border-top: 1px solid var(--border);
   text-align: left;
-  font-size: 13px;
+  font-size: 0.72rem;
   color: var(--accent);
   cursor: pointer;
   flex-shrink: 0;
@@ -355,7 +355,7 @@
 .add-feed-form input {
   width: 100%;
   padding: 6px 8px;
-  font-size: 13px;
+  font-size: 0.72rem;
   background: var(--code-bg);
   border: 1px solid var(--border);
   border-radius: 4px;
@@ -444,7 +444,7 @@
   border: none;
   cursor: pointer;
   color: var(--text);
-  font-size: 16px;
+  font-size: 0.89rem;
   line-height: 1;
   padding: 0 2px;
   flex-shrink: 0;
@@ -468,7 +468,7 @@
 .btn {
   flex: 1;
   padding: 6px 10px;
-  font-size: 13px;
+  font-size: 0.72rem;
   border-radius: 4px;
   border: 1px solid transparent;
   cursor: pointer;
@@ -522,7 +522,7 @@
   display: block;
   width: 100%;
   padding: 7px 10px;
-  font-size: 14px;
+  font-size: 0.78rem;
   font-weight: normal;
   text-align: left;
   background: none;
@@ -557,7 +557,7 @@
 }
 
 .settings-section-title {
-  font-size: 13px;
+  font-size: 0.72rem;
   font-weight: 600;
   color: var(--text-h);
   text-transform: uppercase;
@@ -582,7 +582,7 @@
   border: 1px dashed var(--border);
   border-radius: 6px;
   cursor: pointer;
-  font-size: 13px;
+  font-size: 0.72rem;
   color: var(--text);
   transition: border-color 0.15s, background 0.15s;
 
@@ -593,7 +593,7 @@
 }
 
 .settings-hint {
-  font-size: 12px;
+  font-size: 0.67rem;
   color: var(--text);
   opacity: 0.6;
   margin: 0;
@@ -601,7 +601,7 @@
 }
 
 .settings-status {
-  font-size: 13px;
+  font-size: 0.72rem;
   margin: 0;
 }
 
@@ -619,7 +619,7 @@
   gap: 12px;
 
   label {
-    font-size: 13px;
+    font-size: 0.72rem;
     color: var(--text);
     width: 160px;
     flex-shrink: 0;
@@ -628,7 +628,7 @@
   input {
     flex: 1;
     padding: 6px 8px;
-    font-size: 13px;
+    font-size: 0.72rem;
     background: var(--code-bg);
     border: 1px solid var(--border);
     border-radius: 4px;
@@ -650,9 +650,87 @@
 }
 
 .settings-empty {
-  font-size: 14px;
+  font-size: 0.78rem;
   color: var(--text);
   opacity: 0.5;
+}
+
+/* ── Segmented control ───────────────────────────────────────── */
+
+.segmented {
+  display: inline-flex;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+  background: var(--code-bg);
+}
+
+.segmented-btn {
+  padding: 6px 16px;
+  font-size: 0.72rem;
+  background: none;
+  border: none;
+  border-right: 1px solid var(--border);
+  color: var(--text);
+  cursor: pointer;
+  font-family: var(--sans);
+  transition: background 0.15s, color 0.15s;
+
+  &:last-child {
+    border-right: none;
+  }
+
+  &:hover:not(.active) {
+    background: var(--accent-bg);
+    color: var(--text-h);
+  }
+
+  &.active {
+    background: var(--accent);
+    color: #fff;
+  }
+}
+
+/* ── Appearance settings ─────────────────────────────────────── */
+
+.appearance-accents {
+  display: flex;
+  gap: 8px;
+}
+
+.appearance-accent-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: 2px solid transparent;
+  border-radius: 8px;
+  cursor: pointer;
+  padding: 8px 10px;
+  transition: border-color 0.15s, background 0.15s;
+
+  &:hover {
+    background: var(--accent-bg);
+  }
+
+  &.active {
+    border-color: var(--dot-color);
+  }
+}
+
+.appearance-accent-dot {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: var(--dot-color);
+  display: block;
+}
+
+.appearance-accent-label {
+  font-size: 0.61rem;
+  color: var(--text);
+  text-transform: capitalize;
 }
 
 /* ── Post list ───────────────────────────────────────────────── */
@@ -668,7 +746,7 @@
 
 .posts-tag-chip {
   --tag-color: var(--text);
-  font-size: 11px;
+  font-size: 0.61rem;
   font-weight: 400;
   padding: 2px 10px;
   border-radius: 10px;
@@ -710,7 +788,7 @@
   border-radius: 6px;
   color: var(--text-h);
   cursor: pointer;
-  font-size: 16px;
+  font-size: 0.89rem;
 
   &:hover:not(:disabled) {
     background: var(--hover-bg);
@@ -734,7 +812,7 @@
 .posts-search {
   width: 100%;
   padding: 8px 12px;
-  font-size: 14px;
+  font-size: 0.78rem;
   background: var(--code-bg);
   border: 1px solid var(--border);
   border-radius: 6px;
@@ -753,7 +831,7 @@
 }
 
 .posts-group-label {
-  font-size: 12px;
+  font-size: 0.67rem;
   font-weight: 600;
   color: var(--text);
   opacity: 0.6;
@@ -766,7 +844,7 @@
 }
 
 .posts-group-count {
-  font-size: 11px;
+  font-size: 0.61rem;
   font-weight: 600;
   color: var(--accent);
   background: var(--accent-bg);
@@ -792,7 +870,7 @@
   padding: 10px 14px;
   text-decoration: none;
   color: var(--text-h);
-  font-size: 14px;
+  font-size: 0.78rem;
   border-bottom: 1px solid var(--border);
   line-height: 1.4;
 
@@ -822,7 +900,7 @@
 }
 
 .post-item-feed {
-  font-size: 10px;
+  font-size: 0.56rem;
   font-weight: 700;
   letter-spacing: 0.5px;
   color: var(--accent);
@@ -836,7 +914,7 @@
 .post-item-tag {
   --tag-color: var(--text);
   flex-shrink: 0;
-  font-size: 10px;
+  font-size: 0.56rem;
   font-weight: 500;
   padding: 1px 5px;
   border-radius: 3px;
@@ -860,7 +938,7 @@
   border: none;
   cursor: pointer;
   color: var(--text);
-  font-size: 12px;
+  font-size: 0.67rem;
   line-height: 1;
   padding: 0 2px;
   flex-shrink: 0;
@@ -883,7 +961,7 @@
   border: none;
   cursor: pointer;
   color: var(--text);
-  font-size: 14px;
+  font-size: 0.78rem;
   line-height: 1;
   padding: 0 2px;
   flex-shrink: 0;
@@ -909,7 +987,7 @@
 
 .load-more-btn {
   padding: 7px 20px;
-  font-size: 13px;
+  font-size: 0.72rem;
   background: none;
   border: 1px solid var(--border);
   border-radius: 6px;
@@ -944,7 +1022,7 @@
   background: none;
   border: none;
   cursor: pointer;
-  font-size: 20px;
+  font-size: 1.11rem;
   line-height: 1;
   color: var(--text);
   padding: 2px 6px;
@@ -961,7 +1039,7 @@
   background: none;
   border: none;
   cursor: pointer;
-  font-size: 20px;
+  font-size: 1.11rem;
   line-height: 1;
   color: var(--text);
   padding: 2px 6px;
@@ -986,7 +1064,7 @@
 }
 
 .post-reader-title {
-  font-size: 22px;
+  font-size: 1.22rem;
   font-weight: 600;
   color: var(--text-h);
   line-height: 1.3;
@@ -994,7 +1072,7 @@
 }
 
 .post-reader-meta {
-  font-size: 13px;
+  font-size: 0.72rem;
   color: var(--text);
   margin-bottom: 24px;
   display: flex;
@@ -1012,7 +1090,7 @@
 }
 
 .post-reader-body {
-  font-size: 15px;
+  font-size: 0.83rem;
   line-height: 1.7;
   color: var(--text);
 
@@ -1039,14 +1117,14 @@
     padding: 12px 16px;
     border-radius: 6px;
     overflow-x: auto;
-    font-size: 14px;
+    font-size: 0.78rem;
   }
 
   code {
     background: var(--code-bg);
     padding: 2px 5px;
     border-radius: 3px;
-    font-size: 14px;
+    font-size: 0.78rem;
   }
 
   pre code {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 import "./App.css";
 import { PostList } from "./components/PostList";
+import { ThemeProvider } from "./context/ThemeProvider";
 import { AppLayout } from "./pages/AppLayout";
 import { ReaderPage } from "./pages/ReaderPage";
 import { SettingsPage } from "./pages/SettingsPage";
@@ -10,6 +11,7 @@ const qc = new QueryClient();
 
 export default function App() {
   return (
+    <ThemeProvider>
     <QueryClientProvider client={qc}>
       <BrowserRouter>
         <Routes>
@@ -28,5 +30,6 @@ export default function App() {
         </Routes>
       </BrowserRouter>
     </QueryClientProvider>
+    </ThemeProvider>
   );
 }

--- a/web/src/components/settings/Appearance.tsx
+++ b/web/src/components/settings/Appearance.tsx
@@ -1,3 +1,59 @@
+import { useTheme, PALETTES } from "../../hooks/useTheme";
+import type { AccentKey, FontSize, Theme } from "../../hooks/useTheme";
+
 export function Appearance() {
-  return <div className="settings-empty">Coming soon</div>;
+  const { theme, setTheme, accent, setAccent, fontSize, setFontSize } = useTheme();
+
+  return (
+    <div className="settings-section">
+      <h2 className="settings-section-title">Theme</h2>
+      <div className="settings-field">
+        <label>Mode</label>
+        <div className="segmented">
+          {(["light", "dark"] as Theme[]).map((t) => (
+            <button
+              key={t}
+              className={`segmented-btn${theme === t ? " active" : ""}`}
+              onClick={() => setTheme(t)}
+            >
+              {t === "light" ? "Light" : "Dark"}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <h2 className="settings-section-title">Accent color</h2>
+      <div className="appearance-accents">
+        {(Object.keys(PALETTES) as AccentKey[]).map((key) => (
+          <button
+            key={key}
+            className={`appearance-accent-btn${accent === key ? " active" : ""}`}
+            style={{ "--dot-color": PALETTES[key].light } as React.CSSProperties}
+            onClick={() => setAccent(key)}
+            title={key}
+          >
+            <span className="appearance-accent-dot" />
+            <span className="appearance-accent-label">{key}</span>
+          </button>
+        ))}
+      </div>
+
+      <h2 className="settings-section-title">Font size</h2>
+      <div className="settings-field">
+        <label>Size</label>
+        <div className="segmented">
+          {(["small", "default", "large"] as FontSize[]).map((s) => (
+            <button
+              key={s}
+              className={`segmented-btn${fontSize === s ? " active" : ""}`}
+              onClick={() => setFontSize(s)}
+            >
+              {s.charAt(0).toUpperCase() + s.slice(1)}
+            </button>
+          ))}
+        </div>
+      </div>
+      <p className="settings-hint">Changes apply immediately.</p>
+    </div>
+  );
 }

--- a/web/src/context/ThemeContext.ts
+++ b/web/src/context/ThemeContext.ts
@@ -1,0 +1,14 @@
+import { createContext } from "react";
+import type { AccentKey, FontSize, Theme } from "../hooks/useTheme";
+
+export interface ThemeContextValue {
+  theme: Theme;
+  setTheme: (t: Theme) => void;
+  toggleTheme: () => void;
+  accent: AccentKey;
+  setAccent: (key: AccentKey) => void;
+  fontSize: FontSize;
+  setFontSize: (size: FontSize) => void;
+}
+
+export const ThemeContext = createContext<ThemeContextValue | null>(null);

--- a/web/src/context/ThemeProvider.tsx
+++ b/web/src/context/ThemeProvider.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState, type ReactNode } from "react";
+import { ThemeContext, type ThemeContextValue } from "./ThemeContext";
+import { PALETTES } from "../hooks/useTheme";
+import type { AccentKey, FontSize, Theme } from "../hooks/useTheme";
+
+const FONT_SIZE_MAP: Record<FontSize, string> = {
+  small: "15px",
+  default: "18px",
+  large: "21px",
+};
+
+function hexToRgb(hex: string): [number, number, number] {
+  const n = parseInt(hex.slice(1), 16);
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+}
+
+function applyAccent(hex: string, isDark: boolean) {
+  const [r, g, b] = hexToRgb(hex);
+  const alpha = isDark ? 0.15 : 0.1;
+  const root = document.documentElement;
+  root.style.setProperty("--accent", hex);
+  root.style.setProperty("--accent-bg", `rgba(${r}, ${g}, ${b}, ${alpha})`);
+  root.style.setProperty("--accent-border", `rgba(${r}, ${g}, ${b}, 0.5)`);
+}
+
+function getInitialTheme(): Theme {
+  const saved = localStorage.getItem("theme");
+  if (saved === "light" || saved === "dark") return saved;
+  return "dark";
+}
+
+function getInitialAccent(): AccentKey {
+  const saved = localStorage.getItem("accent");
+  if (saved && saved in PALETTES) return saved as AccentKey;
+  return "orange";
+}
+
+function getInitialFontSize(): FontSize {
+  const saved = localStorage.getItem("font-size");
+  if (saved === "small" || saved === "default" || saved === "large") return saved;
+  return "default";
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>(getInitialTheme);
+  const [accent, setAccentState] = useState<AccentKey>(getInitialAccent);
+  const [fontSize, setFontSizeState] = useState<FontSize>(getInitialFontSize);
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = theme;
+    localStorage.setItem("theme", theme);
+    applyAccent(PALETTES[accent][theme], theme === "dark");
+  }, [theme, accent]);
+
+  useEffect(() => {
+    document.documentElement.style.setProperty("--font-base", FONT_SIZE_MAP[fontSize]);
+    localStorage.setItem("font-size", fontSize);
+  }, [fontSize]);
+
+  const value: ThemeContextValue = {
+    theme,
+    setTheme: (t) => setThemeState(t),
+    toggleTheme: () => setThemeState((t) => (t === "dark" ? "light" : "dark")),
+    accent,
+    setAccent: (key) => {
+      setAccentState(key);
+      localStorage.setItem("accent", key);
+    },
+    fontSize,
+    setFontSize: (size) => setFontSizeState(size),
+  };
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}

--- a/web/src/hooks/useTheme.ts
+++ b/web/src/hooks/useTheme.ts
@@ -1,4 +1,5 @@
-import { useEffect, useState } from "react";
+import { useContext } from "react";
+import { ThemeContext } from "../context/ThemeContext";
 
 export const PALETTES = {
   orange: { light: "#e8500a", dark: "#fb8040" },
@@ -9,50 +10,11 @@ export const PALETTES = {
 } as const;
 
 export type AccentKey = keyof typeof PALETTES;
-type Theme = "light" | "dark";
-
-function hexToRgb(hex: string): [number, number, number] {
-  const n = parseInt(hex.slice(1), 16);
-  return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
-}
-
-function applyAccent(hex: string, isDark: boolean) {
-  const [r, g, b] = hexToRgb(hex);
-  const alpha = isDark ? 0.15 : 0.1;
-  const root = document.documentElement;
-  root.style.setProperty("--accent", hex);
-  root.style.setProperty("--accent-bg", `rgba(${r}, ${g}, ${b}, ${alpha})`);
-  root.style.setProperty("--accent-border", `rgba(${r}, ${g}, ${b}, 0.5)`);
-}
-
-function getInitialTheme(): Theme {
-  const saved = localStorage.getItem("theme");
-  if (saved === "light" || saved === "dark") return saved;
-  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
-}
-
-function getInitialAccent(): AccentKey {
-  const saved = localStorage.getItem("accent");
-  if (saved && saved in PALETTES) return saved as AccentKey;
-  return "orange";
-}
+export type Theme = "light" | "dark";
+export type FontSize = "small" | "default" | "large";
 
 export function useTheme() {
-  const [theme, setThemeState] = useState<Theme>(getInitialTheme);
-  const [accent, setAccentState] = useState<AccentKey>(getInitialAccent);
-
-  useEffect(() => {
-    document.documentElement.dataset.theme = theme;
-    localStorage.setItem("theme", theme);
-    applyAccent(PALETTES[accent][theme], theme === "dark");
-  }, [theme, accent]);
-
-  const toggleTheme = () => setThemeState((t) => (t === "dark" ? "light" : "dark"));
-
-  const setAccent = (key: AccentKey) => {
-    setAccentState(key);
-    localStorage.setItem("accent", key);
-  };
-
-  return { theme, toggleTheme, accent, setAccent };
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error("useTheme must be used within ThemeProvider");
+  return ctx;
 }

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -15,7 +15,9 @@
   --heading: system-ui, 'Segoe UI', Roboto, sans-serif;
   --mono: ui-monospace, Consolas, monospace;
 
-  font: 18px/145% var(--sans);
+  font-size: var(--font-base, 18px);
+  line-height: 145%;
+  font-family: var(--sans);
   letter-spacing: 0.18px;
   color-scheme: light dark;
   color: var(--text);
@@ -24,10 +26,6 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-
-  @media (max-width: 1024px) {
-    font-size: 16px;
-  }
 }
 
 @media (prefers-color-scheme: dark) {
@@ -118,7 +116,7 @@ code,
 }
 
 code {
-  font-size: 15px;
+  font-size: 0.83rem;
   line-height: 135%;
   padding: 4px 8px;
   background: var(--code-bg);


### PR DESCRIPTION
Related to https://github.com/kryoseu/WyrmRSS/issues/28.

Adds an Appearance tab to Settings with light/dark toggle, accent colour picker, and small/default/large font size selector. Converts App.css font sizes to rem so they scale off the root. Puts theme state into a React context so sidebar and settings stay in sync.