### PR TITLE
perf: virtualize post and archive lists, fix scroll-triggered fetches

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.100.14",
+    "@tanstack/react-virtual": "^3.14.2",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-icons": "^5.6.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.100.14
         version: 5.100.14(react@19.2.7)
+      '@tanstack/react-virtual':
+        specifier: ^3.14.2
+        version: 3.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -331,6 +334,15 @@ packages:
     resolution: {integrity: sha512-oOr6aRdSFEwWhzxEkD/9ZcItM3+LjBSkeVmadWKwUssAHTsqd/7bOjWrX4AbvEkoEhgAxzN0Xk6H/aYzXiYBAw==}
     peerDependencies:
       react: ^18 || ^19
+
+  '@tanstack/react-virtual@3.14.2':
+    resolution: {integrity: sha512-IpWnmCLvuymRfeeLNVXIzNEYBFLpd3drVIS91sqV78VTZFyldlChkOocZRCPp1B+Wnk09bcLNme8WaMU/9/9bQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/virtual-core@3.17.0':
+    resolution: {integrity: sha512-gOxY/hFkPh/XQYhnThBHzkbkX3Ed+z/iushyz+R+JAr213aXxUDgQoTgTdrDpBSRsjFM73P/KfUyWmaF9WHMkQ==}
 
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
@@ -1267,6 +1279,14 @@ snapshots:
     dependencies:
       '@tanstack/query-core': 5.100.14
       react: 19.2.7
+
+  '@tanstack/react-virtual@3.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@tanstack/virtual-core': 3.17.0
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
+  '@tanstack/virtual-core@3.17.0': {}
 
   '@tybys/wasm-util@0.10.2':
     dependencies:

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -937,12 +937,6 @@
   flex-shrink: 0;
 }
 
-.posts-toolbar-title {
-  font-size: 0.78rem;
-  font-weight: 600;
-  color: var(--text-h);
-}
-
 .posts-refresh-btn {
   display: flex;
   align-items: center;
@@ -1021,12 +1015,27 @@
   opacity: 1;
 }
 
-.posts-group-items {
-  border: 1px solid var(--border);
+/* Virtual list card simulation — borders live on the row wrapper, not the item */
+.post-card-item {
+  margin: 0 16px;
+  border-left: 1px solid var(--border);
+  border-right: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+}
+
+.post-card-item--first {
+  border-top: 1px solid var(--border);
+  border-radius: 6px 6px 0 0;
+  overflow: hidden;
+}
+
+.post-card-item--last {
+  border-radius: 0 0 6px 6px;
+  overflow: hidden;
+}
+
+.post-card-item--first.post-card-item--last {
   border-radius: 6px;
-  overflow-y: auto;
-  max-height: 400px;
-  margin-bottom: 8px;
 }
 
 .post-item {
@@ -1037,12 +1046,7 @@
   text-decoration: none;
   color: var(--text-h);
   font-size: 0.78rem;
-  border-bottom: 1px solid var(--border);
   line-height: 1.4;
-
-  &:last-child {
-    border-bottom: none;
-  }
 
   &:hover {
     background: var(--accent-bg);

--- a/web/src/components/ArchiveItem.tsx
+++ b/web/src/components/ArchiveItem.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import { Link } from "react-router-dom";
 import { TbArchiveOff } from "react-icons/tb";
 import type { PostArchive } from "../types/PostArchive";
@@ -8,7 +9,7 @@ interface Props {
   active: boolean;
 }
 
-export function ArchiveItem({ archive, active }: Props) {
+export const ArchiveItem = memo(function ArchiveItem({ archive, active }: Props) {
   const { mutate: unarchive } = useUnarchivePost();
 
   function handleUnarchive(e: React.MouseEvent) {
@@ -40,4 +41,4 @@ export function ArchiveItem({ archive, active }: Props) {
       </button>
     </Link>
   );
-}
+});

--- a/web/src/components/ArchiveList.tsx
+++ b/web/src/components/ArchiveList.tsx
@@ -2,8 +2,8 @@ import { useEffect, useMemo, useState } from "react";
 import { useOutletContext, useParams } from "react-router-dom";
 import { useArchivedPosts } from "../hooks/usePosts";
 import { ArchiveItem } from "./ArchiveItem";
+import { VirtualGroupedList } from "./VirtualGroupedList";
 import type { ReaderOutletContext } from "../pages/ReaderPage";
-import { groupByDate } from "../utils/posts";
 
 export function ArchiveList() {
   const { activePostId, onOpenPost } = useOutletContext<ReaderOutletContext>();
@@ -13,13 +13,14 @@ export function ArchiveList() {
   const [debouncedSearch, setDebouncedSearch] = useState("");
   const [activeTag, setActiveTag] = useState<string | undefined>(undefined);
 
+  // Delay search query until the user stops typing
   useEffect(() => {
-    const timer = setTimeout(() => setDebouncedSearch(search || ""), 300);
+    const timer = setTimeout(() => setDebouncedSearch(search), 300);
     return () => clearTimeout(timer);
   }, [search]);
 
   // Data kept in cache for tag chip discovery.
-  // PostList doesn't need because tags are derived from feeds.
+  // PostList doesn't need this because tags are derived from feeds.
   const { data: cachedData } = useArchivedPosts();
   const { data, isLoading, hasNextPage, fetchNextPage, isFetchingNextPage } =
     useArchivedPosts(debouncedSearch || undefined, activeTag);
@@ -28,19 +29,20 @@ export function ArchiveList() {
     if (postId) onOpenPost(Number(postId));
   }, [postId, onOpenPost]);
 
-  const archives = useMemo(() => data?.pages.flatMap((p) => p.items) ?? [], [data]);
-  const groups = groupByDate(archives);
+  const items = useMemo(
+    () => data?.pages.flatMap((p) => p.items),
+    [data]
+  );
 
-  const tagMap = useMemo(() => {
-    const map = new Map<string, string | undefined>();
+  const { tagMap, tagKeys } = useMemo(() => {
+    const tagMap = new Map<string, string | undefined>();
     for (const page of cachedData?.pages ?? []) {
       for (const item of page.items) {
-        if (item.tag) map.set(item.tag, item.tag_color ?? undefined);
+        if (item.tag) tagMap.set(item.tag, item.tag_color ?? undefined);
       }
     }
-    return map;
+    return { tagMap, tagKeys: [...tagMap.keys()] };
   }, [cachedData]);
-  const tagKeys = [...tagMap.keys()];
 
   return (
     <div className="pane pane-posts">
@@ -58,7 +60,7 @@ export function ArchiveList() {
             <button
               key={tag}
               className={`posts-tag-chip${activeTag === tag ? " active" : ""}`}
-              style={{ '--tag-color': tagMap.get(tag) ?? 'var(--text)' } as React.CSSProperties}
+              style={{ "--tag-color": tagMap.get(tag) ?? "var(--text)" } as React.CSSProperties}
               onClick={() => setActiveTag((prev) => (prev === tag ? undefined : tag))}
             >
               {tag}
@@ -66,40 +68,20 @@ export function ArchiveList() {
           ))}
         </div>
       )}
-      <div className="pane-scroll">
-        {isLoading && <div className="pane-empty">Loading…</div>}
-        {!isLoading && archives.length === 0 && (
-          <div className="pane-empty">No archived posts</div>
+      <VirtualGroupedList
+        items={items}
+        isLoading={isLoading}
+        hasNextPage={hasNextPage}
+        fetchNextPage={fetchNextPage}
+        isFetchingNextPage={isFetchingNextPage}
+        emptyMessage="No archived posts"
+        renderItem={(archive) => (
+          <ArchiveItem
+            archive={archive}
+            active={activePostId === archive.id}
+          />
         )}
-        {groups.map(([label, items]) => (
-          <div key={label} className="posts-group">
-            <div className="posts-group-label">
-              <span>{label}</span>
-              <span className="posts-group-count">{items.length}</span>
-            </div>
-            <div className="posts-group-items">
-              {items.map((a) => (
-                <ArchiveItem
-                  key={a.id}
-                  archive={a}
-                  active={activePostId === a.id}
-                />
-              ))}
-            </div>
-          </div>
-        ))}
-        {hasNextPage && (
-          <div className="load-more">
-            <button
-              className="load-more-btn"
-              onClick={() => fetchNextPage()}
-              disabled={isFetchingNextPage}
-            >
-              {isFetchingNextPage ? "Loading…" : "Load more"}
-            </button>
-          </div>
-        )}
-      </div>
+      />
     </div>
   );
 }

--- a/web/src/components/PostItem.tsx
+++ b/web/src/components/PostItem.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import { Link } from "react-router-dom";
 import { HiMail, HiMailOpen } from "react-icons/hi";
 import { TbArchive, TbArchiveOff, TbStar, TbStarFilled } from "react-icons/tb";
@@ -19,7 +20,7 @@ interface Props {
   feed?: FeedMeta;
 }
 
-export function PostItem({ post, to, active, feed }: Props) {
+export const PostItem = memo(function PostItem({ post, to, active, feed }: Props) {
   const { mutate: updatePost } = useUpdatePost();
   const { mutate: archivePost } = useArchivePost();
   const { mutate: unarchivePost } = useUnarchivePost();
@@ -97,4 +98,4 @@ export function PostItem({ post, to, active, feed }: Props) {
       </button>
     </Link>
   );
-}
+});

--- a/web/src/components/PostList.tsx
+++ b/web/src/components/PostList.tsx
@@ -1,11 +1,12 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useLocation, useOutletContext, useParams } from "react-router-dom";
 import { TbRefresh } from "react-icons/tb";
 import { useFavoritePosts, usePosts } from "../hooks/usePosts";
 import { useFeeds, usePollFeeds } from "../hooks/useFeeds";
 import { PostItem, type FeedMeta } from "./PostItem";
+import { VirtualGroupedList } from "./VirtualGroupedList";
 import type { ReaderOutletContext } from "../pages/ReaderPage";
-import { groupByDate, postPath } from "../utils/posts";
+import { postPath } from "../utils/posts";
 
 export function PostList() {
   const { excludedFeeds, activePostId, onOpenPost } = useOutletContext<ReaderOutletContext>();
@@ -17,12 +18,12 @@ export function PostList() {
   const feedIdNum = feedId ? Number(feedId) : undefined;
 
   const { data: feeds } = useFeeds();
-
   const pollFeeds = usePollFeeds();
   const favoritePosts = useFavoritePosts();
 
   const [search, setSearch] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
+
   const [activeTag, setActiveTag] = useState<string | undefined>(undefined);
 
   // Reset activeTag on navigation. setState during render (vs. useEffect) avoids rendering once
@@ -37,7 +38,7 @@ export function PostList() {
 
   // Delay search query until the user stops typing
   useEffect(() => {
-    const timer = setTimeout(() => setDebouncedSearch(search || ""), 300);
+    const timer = setTimeout(() => setDebouncedSearch(search), 300);
     return () => clearTimeout(timer);
   }, [search]);
 
@@ -49,34 +50,41 @@ export function PostList() {
     hasNextPage,
     fetchNextPage,
     isFetchingNextPage,
-    isRefetching
+    isRefetching,
   } = isFavorites ? favoritePosts : feedPosts;
 
-  const feedMap = new Map(
-    (feeds ?? []).map((f): [number, FeedMeta] => [
-      f.id,
-      { name: f.title, tag: f.tag, tagColor: f.tag_color },
-    ])
+  // Keep the same FeedMeta object references between renders so React.memo on PostItem can bail out
+  const feedMap = useMemo(
+    () =>
+      new Map(
+        (feeds ?? []).map((f): [number, FeedMeta] => [
+          f.id,
+          { name: f.title, tag: f.tag, tagColor: f.tag_color },
+        ])
+      ),
+    [feeds]
   );
 
-  const tagMap = new Map(
-    (feeds ?? [])
-      .filter((f) => f.tag !== undefined)
-      .map((f) => [f.tag!, f.tag_color])
-  );
-  const tags = [...tagMap.keys()];
+  // Same — avoid recreating tag arrays on every render
+  const { tagMap, tags } = useMemo(() => {
+    const tagMap = new Map(
+      (feeds ?? [])
+        .filter((f) => f.tag !== undefined)
+        .map((f) => [f.tag!, f.tag_color])
+    );
+    return { tagMap, tags: [...tagMap.keys()] };
+  }, [feeds]);
 
   useEffect(() => {
     if (postId) onOpenPost(Number(postId));
   }, [postId, onOpenPost]);
 
-  const posts = data?.pages.flatMap((p) => p.items);
-  // Filter out posts whose feed.id are in the excluded list, 
-  // unless we're on the favorites or on a feed page.
-  const filtered = posts?.filter((p) =>
-    isFavorites || feedIdNum !== undefined || !excludedFeeds.has(p.feed_id)
-  );
-  const groups = filtered ? groupByDate(filtered) : [];
+  const items = useMemo(() => {
+    const posts = data?.pages.flatMap((p) => p.items);
+    return posts?.filter(
+      (p) => isFavorites || feedIdNum !== undefined || !excludedFeeds.has(p.feed_id)
+    );
+  }, [data, excludedFeeds, isFavorites, feedIdNum]);
 
   return (
     <div className="pane pane-posts">
@@ -102,7 +110,7 @@ export function PostList() {
             <button
               key={tag}
               className={`posts-tag-chip${activeTag === tag ? " active" : ""}`}
-              style={{ '--tag-color': tagMap.get(tag) ?? 'var(--text)' } as React.CSSProperties}
+              style={{ "--tag-color": tagMap.get(tag) ?? "var(--text)" } as React.CSSProperties}
               onClick={() => setActiveTag((prev) => (prev === tag ? undefined : tag))}
             >
               {tag}
@@ -110,42 +118,22 @@ export function PostList() {
           ))}
         </div>
       )}
-      <div className="pane-scroll">
-        {isLoading && <div className="pane-empty">Loading…</div>}
-        {!isLoading && groups.length === 0 && (
-          <div className="pane-empty">{isFavorites ? "No favorites yet" : "No posts"}</div>
+      <VirtualGroupedList
+        items={items}
+        isLoading={isLoading}
+        hasNextPage={hasNextPage}
+        fetchNextPage={fetchNextPage}
+        isFetchingNextPage={isFetchingNextPage}
+        emptyMessage={isFavorites ? "No favorites yet" : "No posts"}
+        renderItem={(post) => (
+          <PostItem
+            post={post}
+            to={postPath(post, feedIdNum, isFavorites)}
+            active={activePostId === post.id}
+            feed={feedIdNum === undefined ? feedMap.get(post.feed_id) : undefined}
+          />
         )}
-        {groups.map(([label, groupPosts]) => (
-          <div key={label} className="posts-group">
-            <div className="posts-group-label">
-              <span>{label}</span>
-              <span className="posts-group-count">{groupPosts.length}</span>
-            </div>
-            <div className="posts-group-items">
-              {groupPosts.map((p) => (
-                <PostItem
-                  key={p.id}
-                  post={p}
-                  to={postPath(p, feedIdNum, isFavorites)}
-                  active={activePostId === p.id}
-                  feed={feedIdNum === undefined ? feedMap.get(p.feed_id) : undefined}
-                />
-              ))}
-            </div>
-          </div>
-        ))}
-        {hasNextPage && (
-          <div className="load-more">
-            <button
-              className="load-more-btn"
-              onClick={() => fetchNextPage()}
-              disabled={isFetchingNextPage}
-            >
-              {isFetchingNextPage ? "Loading…" : "Load more"}
-            </button>
-          </div>
-        )}
-      </div>
+      />
     </div>
   );
 }

--- a/web/src/components/VirtualGroupedList.tsx
+++ b/web/src/components/VirtualGroupedList.tsx
@@ -39,6 +39,7 @@ export function VirtualGroupedList<T extends { published_at: string }>({
   }, [items, hasNextPage]);
 
   const scrollRef = useRef<HTMLDivElement>(null);
+  // eslint-disable-next-line react-hooks/incompatible-library
   const virtualizer = useVirtualizer({
     count: rows.length,
     getScrollElement: () => scrollRef.current,

--- a/web/src/components/VirtualGroupedList.tsx
+++ b/web/src/components/VirtualGroupedList.tsx
@@ -1,0 +1,98 @@
+import { useMemo, useRef } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { groupByDate } from "../utils/posts";
+
+type VRow<T> =
+  | { kind: "header"; label: string; count: number }
+  | { kind: "item"; item: T; isGroupFirst: boolean; isGroupLast: boolean }
+  | { kind: "load-more" };
+
+interface Props<T extends { published_at: string }> {
+  items: T[] | undefined;
+  isLoading: boolean;
+  hasNextPage: boolean | undefined;
+  fetchNextPage: () => void;
+  isFetchingNextPage: boolean;
+  renderItem: (item: T) => React.ReactNode;
+  emptyMessage: string;
+}
+
+export function VirtualGroupedList<T extends { published_at: string }>({
+  items,
+  isLoading,
+  hasNextPage,
+  fetchNextPage,
+  isFetchingNextPage,
+  renderItem,
+  emptyMessage,
+}: Props<T>) {
+  const rows = useMemo<VRow<T>[]>(() => {
+    const result: VRow<T>[] = [];
+    for (const [label, groupItems] of items ? groupByDate(items) : []) {
+      result.push({ kind: "header", label, count: groupItems.length });
+      for (const [i, item] of groupItems.entries()) {
+        result.push({ kind: "item", item, isGroupFirst: i === 0, isGroupLast: i === groupItems.length - 1 });
+      }
+    }
+    if (hasNextPage) result.push({ kind: "load-more" });
+    return result;
+  }, [items, hasNextPage]);
+
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const virtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => 41,
+    overscan: 10,
+  });
+
+  const isEmpty = !isLoading && rows.length === 0;
+
+  return (
+    <div className="pane-scroll" ref={scrollRef}>
+      {isLoading && <div className="pane-empty">Loading…</div>}
+      {isEmpty && <div className="pane-empty">{emptyMessage}</div>}
+      {!isLoading && rows.length > 0 && (
+        <div style={{ height: virtualizer.getTotalSize(), position: "relative" }}>
+          {virtualizer.getVirtualItems().map((vItem) => {
+            const row = rows[vItem.index];
+            return (
+              <div
+                key={vItem.key}
+                data-index={vItem.index}
+                ref={virtualizer.measureElement}
+                className={
+                  row.kind === "item"
+                    ? `post-card-item${row.isGroupFirst ? " post-card-item--first" : ""}${row.isGroupLast ? " post-card-item--last" : ""}`
+                    : undefined
+                }
+                style={{ position: "absolute", top: vItem.start, left: 0, right: 0 }}
+              >
+                {row.kind === "header" && (
+                  <div className="posts-group">
+                    <div className="posts-group-label">
+                      <span>{row.label}</span>
+                      <span className="posts-group-count">{row.count}</span>
+                    </div>
+                  </div>
+                )}
+                {row.kind === "item" && renderItem(row.item)}
+                {row.kind === "load-more" && (
+                  <div className="load-more">
+                    <button
+                      className="load-more-btn"
+                      onClick={() => fetchNextPage()}
+                      disabled={isFetchingNextPage}
+                    >
+                      {isFetchingNextPage ? "Loading…" : "Load more"}
+                    </button>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/hooks/usePosts.ts
+++ b/web/src/hooks/usePosts.ts
@@ -119,12 +119,14 @@ export function useUpdatePost() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: ({ id, ...data }: { id: number } & UpdatePost) => updatePost(id, data),
-    onSuccess: (post: Post) => {
+    onSuccess: (post: Post, variables) => {
       const patch = (p: Post) => p.id === post.id ? post : p;
       queryClient.setQueryData(postKeys.detail(post.id), post);
       queryClient.setQueriesData({ queryKey: ["posts", "list"] }, (cached: PostPages) => patchPostInPages(cached, patch));
       queryClient.setQueryData(postKeys.byFeed(post.feed_id), (cached: PostPages) => patchPostInPages(cached, patch));
-      queryClient.invalidateQueries({ queryKey: postKeys.favorites });
+      if (variables.is_favorite !== null) {
+        queryClient.invalidateQueries({ queryKey: postKeys.favorites });
+      }
     },
   });
 }

--- a/web/src/hooks/useSettings.ts
+++ b/web/src/hooks/useSettings.ts
@@ -6,6 +6,7 @@ export function useSettings() {
   return useQuery({
     queryKey: ["settings"],
     queryFn: getSettings,
+    staleTime: Infinity,
   });
 }
 


### PR DESCRIPTION
- Add `@tanstack/react-virtual` for `PostList` and `ArchiveList`. Improves long post list rendering, which was causing the browser to lag with 1000+ posts, by making the browser only render the posts that the user can see, as the user scrolls.

- Extract shared `VirtualGroupedList<T>` component, which owns the virtualizer, `VRow` type, grouped rows, card wrapper classes, and all virtual rendering; PostList and ArchiveList pass pre-filtered `items` and a `renderItem` function

- Wrap `PostItem` and `ArchiveItem` with `React.memo`
- `useMemo` on `feedMap` and `tagMap` in `PostList` to keep `FeedMeta` object references stable so memo can bail out on unchanged items

- `useSettings`: add `staleTime: Infinity` — was refetching on every virtual item mount as the user scrolled
- `useUpdatePost`: only `invalidateQueries(favorites)` when `is_favorite !== null` — was firing a GET `/posts/favorites` on every read-mark

The result of these changes is smooth scrolling and instant post opens at 1000–2000+ posts.