### PR TITLE
feat: add API key authentication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,6 +186,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-web-httpauth"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456348ed9dcd72a13a1f4a660449fafdecee9ac8205552e286809eb5b0b29bd3"
+dependencies = [
+ "actix-utils",
+ "actix-web",
+ "base64",
+ "futures-core",
+ "futures-util",
+ "log",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -260,8 +275,10 @@ name = "api_routes"
 version = "0.12.3"
 dependencies = [
  "actix-web",
+ "actix-web-httpauth",
  "api_api",
  "api_crud",
+ "wyrm_utils",
 ]
 
 [[package]]
@@ -3998,6 +4015,7 @@ name = "wyrm_utils"
 version = "0.12.3"
 dependencies = [
  "actix-web",
+ "actix-web-httpauth",
  "config",
  "deadpool",
  "diesel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ rust-version = "1.94.1"
 [workspace.dependencies]
 tokio = { version = "1.52.3", features = ["full"] }
 actix-web = "4.13.0"
+actix-web-httpauth = "0.8.2"
 actix-files = "0.6.10"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "json"] }

--- a/README.md
+++ b/README.md
@@ -56,7 +56,10 @@ Startup settings can be configured via environment variables (prefixed `WYRM_`) 
 | `WYRM_PORT` | `3001` | Port to listen on |
 | `WYRM_DATABASE_CONNECTION` | `postgres://wyrm:wyrm@localhost/wyrm` | PostgreSQL connection URI |
 | `WYRM_DATABASE_POOL_SIZE` | `30` | Max database connection pool size |
-| `RUST_LOG` | `info` | Log level filter (e.g. `debug`, `wyrm=trace`) |
+| `WYRM_API_KEY` | _(none)_ | API key required by clients; unset means the API is open and any key is accepted |
+
+> [!NOTE]
+> Setting `WYRM_API_KEY` on the backend is enough to restrict access. Setting it on the frontend too skips the in-app key prompt. If left unset on the backend, the API is open and any key entered in the prompt will be accepted.
 
 ### Runtime settings
 
@@ -75,7 +78,8 @@ The following settings are stored in the database and can be changed at runtime 
 
 | Variable | Default | Description |
 |---|---|---|
-| `WYRM_BACKEND_URL` | `http://localhost:3001` | Backend URL used by the Vite preview proxy |
+| `WYRM_BACKEND_URL` | `http://localhost:3001` | Backend URL, must match where the backend is running |
+| `WYRM_API_KEY` | _(none)_ | Bake an API key into the frontend build, skipping the key prompt entirely |
 
 ## YouTube
 

--- a/api/routes/Cargo.toml
+++ b/api/routes/Cargo.toml
@@ -9,5 +9,7 @@ rust-version.workspace = true
 
 [dependencies]
 actix-web = { workspace = true }
+actix-web-httpauth = { workspace = true }
 api_api = { path = "../api" }
 api_crud = { path = "../crud" }
+wyrm_utils = { path = "../../utils" }

--- a/api/routes/src/auth.rs
+++ b/api/routes/src/auth.rs
@@ -1,0 +1,8 @@
+use actix_web::web;
+
+pub fn config(cfg: &mut web::ServiceConfig) {
+    cfg.service(web::scope("/auth").route(
+        "/verify",
+        web::get().to(|| async { actix_web::HttpResponse::Ok().finish() }),
+    ));
+}

--- a/api/routes/src/lib.rs
+++ b/api/routes/src/lib.rs
@@ -1,12 +1,18 @@
 use actix_web::web;
+use actix_web_httpauth::middleware::HttpAuthentication;
+use wyrm_utils::middleware::api_key_middleware;
 
+mod auth;
 mod feeds;
 mod posts;
 mod settings;
 
 pub fn config(cfg: &mut web::ServiceConfig) {
+    let auth = HttpAuthentication::bearer(api_key_middleware);
     cfg.service(
         web::scope("/api/v1")
+            .wrap(auth)
+            .configure(auth::config)
             .configure(posts::config)
             .configure(feeds::config)
             .configure(settings::config),

--- a/config/wyrm-example.toml
+++ b/config/wyrm-example.toml
@@ -1,5 +1,4 @@
-port = 3002 # default 3001
-
-[database]
-connection = "postgres://wyrm:wyrm@localhost/wyrm"
-pool_size = 25                                     # default 30
+port = 3002                                                     # default 3001
+# api_key = "secret123!"                                         # optional, protects the API
+database_connection = "postgres://wyrm:wyrm@localhost/wyrm"
+database_pool_size = 25                                         # default 30

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -27,13 +27,14 @@ pub fn run_migrations(
 }
 
 pub fn establish_sync_connection(conf: &WyrmStartupConfig) -> WyrmResult<PgConnection> {
-    let conn = PgConnection::establish(&conf.database.connection)?;
+    let conn = PgConnection::establish(&conf.database_connection)?;
     Ok(conn)
 }
 
 pub async fn create_pool(conf: &WyrmStartupConfig) -> WyrmResult<DatabasePool> {
-    let config = AsyncDieselConnectionManager::<AsyncPgConnection>::new(&conf.database.connection);
+    let config = AsyncDieselConnectionManager::<AsyncPgConnection>::new(&conf.database_connection);
     Pool::builder(config)
+        .max_size(conf.database_pool_size)
         .build()
         .map_err(|e| WyrmError::Database(DatabaseError::PoolBuildError(e)))
 }

--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -34,9 +34,10 @@ services:
     container_name: wyrm-rss
     environment:
       # all env vars are optional, these are default values
-      WYRM_PORT: 3001 
+      WYRM_PORT: 3001
       WYRM_DATABASE_CONNECTION: "postgres://wyrm:wyrm@wyrm-db/wyrm"
       WYRM_DATABASE_POOL_SIZE: 30
+      # WYRM_API_KEY: "changeme"  # set to protect the API
     ports:
       - 3001:3001
     volumes:
@@ -52,6 +53,7 @@ services:
     environment:
       WYRM_WEB_PORT: 3000
       WYRM_BACKEND_URL: "http://wyrm-server:3001"
+      # WYRM_API_KEY: "changeme"  # must match the server's WYRM_API_KEY
     ports:
       - 3000:3000
     restart: unless-stopped

--- a/docs/installation/source.md
+++ b/docs/installation/source.md
@@ -26,13 +26,13 @@ cargo run -p server
 The server reads configuration from `config/wyrm.toml` in the working directory. Copy and edit the example:
 
 ```bash
-cp config/wyrm.toml.example config/wyrm.toml
+cp config/wyrm-example.toml config/wyrm.toml
 ```
 
 Then install dependencies and run the frontend:
 
 ```bash
-export WYRM_BACKEND_URL: "http://localhost:3001"
+export WYRM_BACKEND_URL="http://localhost:3001"
 
 cd web
 pnpm install
@@ -46,10 +46,9 @@ Backend configuration via  `config/wyrm.toml`:
 
 ```toml
 port = 3001
-
-[database]
-connection = "postgres://wyrm:wyrm@localhost/wyrm"
-pool_size = 25      # default 30
+# api_key = "secret123!"
+database_connection = "postgres://wyrm:wyrm@localhost/wyrm"
+database_pool_size = 25      # default 30
 ```
 
 Settings can also be overridden with environment variables prefixed `WYRM_`, e.g. `WYRM_PORT=8080`.

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -1,10 +1,7 @@
 use actix_web::{App, HttpServer, dev::ServerHandle, web};
 use api_utils::context::WyrmContext;
 use database::{models::settings::Settings, utils::settings::RuntimeSettings};
-use std::{
-    net::IpAddr,
-    sync::{Arc, RwLock},
-};
+use std::sync::{Arc, RwLock};
 use tracing::info;
 use wyrm_rss::{
     http::{HttpClient, HttpConfig},
@@ -53,7 +50,7 @@ pub async fn start_server() -> WyrmResult<()> {
     });
 
     info!("Starting up HTTP server");
-    let server_handle = spin_up_http_server(startup_conf.bind, startup_conf.port, ctx)?;
+    let server_handle = spin_up_http_server(startup_conf, ctx)?;
 
     tokio::select! {
         _ = tokio::signal::ctrl_c() => server_handle.stop(true).await
@@ -63,13 +60,15 @@ pub async fn start_server() -> WyrmResult<()> {
 }
 
 fn spin_up_http_server(
-    bind: IpAddr,
-    port: u16,
+    startup_conf: WyrmStartupConfig,
     ctx: web::Data<WyrmContext>,
 ) -> WyrmResult<ServerHandle> {
+    let bind = startup_conf.bind;
+    let port = startup_conf.port;
     let server = HttpServer::new(move || {
         App::new()
             .app_data(ctx.clone())
+            .app_data(web::Data::new(startup_conf.api_key.clone()))
             .configure(api_routes::config)
     })
     .bind((bind, port))

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -13,6 +13,7 @@ diesel = { workspace = true }
 diesel-async = { workspace = true }
 deadpool = { workspace = true }
 actix-web = { workspace = true }
+actix-web-httpauth = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 serde = { workspace = true }

--- a/utils/src/config.rs
+++ b/utils/src/config.rs
@@ -5,34 +5,29 @@ use std::net::{IpAddr, Ipv4Addr};
 
 #[derive(Debug, Clone, Deserialize, SmartDefault)]
 #[serde(default)]
-pub struct DatabaseConfig {
-    /// Database URI
-    #[default("postgres://wyrm:wyrm@localhost/wyrm")]
-    pub connection: String,
-    /// Max number of active database connections
-    #[default(30)]
-    pub pool_size: usize,
-}
-
-#[derive(Debug, Clone, Deserialize, SmartDefault)]
-#[serde(default)]
 /// Built from wyrm.toml or env vars
 pub struct WyrmStartupConfig {
-    /// Database settings
-    pub database: DatabaseConfig,
+    /// Database connection URI
+    #[default("postgres://wyrm:wyrm@localhost/wyrm")]
+    pub database_connection: String,
+    /// Max number of active database connections
+    #[default(30)]
+    pub database_pool_size: usize,
     /// Bind to IP addr
     #[default(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)))]
     pub bind: IpAddr,
     /// Port to listen on
     #[default(3001)]
     pub port: u16,
+    /// API key
+    pub api_key: Option<String>,
 }
 
 impl WyrmStartupConfig {
     pub fn load() -> Self {
         Config::builder()
             .add_source(File::with_name("config/wyrm.toml").required(false))
-            .add_source(Environment::with_prefix("WYRM").separator("_"))
+            .add_source(Environment::with_prefix("WYRM"))
             .build()
             .unwrap()
             .try_deserialize()

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod config;
 pub mod error;
+pub mod middleware;
 pub mod result;

--- a/utils/src/middleware.rs
+++ b/utils/src/middleware.rs
@@ -1,0 +1,17 @@
+use actix_web::web;
+use actix_web_httpauth::extractors::bearer::BearerAuth;
+
+pub async fn api_key_middleware(
+    req: actix_web::dev::ServiceRequest,
+    credentials: BearerAuth,
+) -> Result<actix_web::dev::ServiceRequest, (actix_web::Error, actix_web::dev::ServiceRequest)> {
+    let expected = req
+        .app_data::<web::Data<Option<String>>>()
+        .and_then(|k| k.as_deref());
+
+    match expected {
+        None => Ok(req),                                    // no key configured - pass
+        Some(key) if credentials.token() == key => Ok(req), // key matches - pass
+        _ => Err((actix_web::error::ErrorUnauthorized("Invalid api key"), req)),
+    }
+}

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1331,3 +1331,59 @@
     font-style: italic;
   }
 }
+
+/* ── API Key Gate ────────────────────────────────────────────── */
+
+.api-key-gate {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg);
+  z-index: 1000;
+}
+
+.api-key-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: 320px;
+  padding: 28px 24px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--code-bg);
+
+  h2 {
+    margin: 0;
+    font-size: 0.94rem;
+    font-weight: 600;
+    color: var(--text-h);
+  }
+
+  p {
+    margin: 0;
+    font-size: 0.72rem;
+    color: var(--text);
+    line-height: 1.5;
+
+    &.api-key-error {
+      color: #ef4444;
+    }
+  }
+
+  input {
+    padding: 7px 10px;
+    font-size: 0.78rem;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 5px;
+    color: var(--text-h);
+    font-family: var(--sans);
+
+    &:focus {
+      outline: 2px solid var(--accent-border);
+      border-color: transparent;
+    }
+  }
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 import "./App.css";
+import { ApiKeyGate } from "./components/ApiKeyGate";
 import { ArchiveList } from "./components/ArchiveList";
 import { PostList } from "./components/PostList";
 import { ThemeProvider } from "./context/ThemeProvider";
@@ -13,6 +14,7 @@ const qc = new QueryClient();
 export default function App() {
   return (
     <ThemeProvider>
+      <ApiKeyGate>
       <QueryClientProvider client={qc}>
         <BrowserRouter>
           <Routes>
@@ -33,6 +35,7 @@ export default function App() {
           </Routes>
         </BrowserRouter>
       </QueryClientProvider>
+      </ApiKeyGate>
     </ThemeProvider>
   );
 }

--- a/web/src/api/feeds.ts
+++ b/web/src/api/feeds.ts
@@ -2,29 +2,30 @@ import type { Feed } from "../types/Feed";
 import type { CreateFeed } from "../types/CreateFeed";
 import type { UpdateFeed } from "../types/UpdateFeed";
 import { ENDPOINTS, json, noContent } from "../utils/api";
+import { fetchWithAuth } from "../utils/auth";
 
 export const getFeeds = (): Promise<Feed[]> =>
-  fetch(ENDPOINTS.feeds.list()).then<Feed[]>(json);
+  fetchWithAuth(ENDPOINTS.feeds.list()).then<Feed[]>(json);
 
 export const getFeed = (id: number): Promise<Feed> =>
-  fetch(ENDPOINTS.feeds.get(id)).then<Feed>(json);
+  fetchWithAuth(ENDPOINTS.feeds.get(id)).then<Feed>(json);
 
 export const createFeed = (body: CreateFeed): Promise<Feed> =>
-  fetch(ENDPOINTS.feeds.create(), {
+  fetchWithAuth(ENDPOINTS.feeds.create(), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
   }).then<Feed>(json);
 
 export const updateFeed = (id: number, body: UpdateFeed): Promise<Feed> =>
-  fetch(ENDPOINTS.feeds.update(id), {
+  fetchWithAuth(ENDPOINTS.feeds.update(id), {
     method: "PATCH",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
   }).then<Feed>(json);
 
 export const deleteFeed = (id: number): Promise<Feed> =>
-  fetch(ENDPOINTS.feeds.delete(id), { method: "DELETE" }).then<Feed>(json);
+  fetchWithAuth(ENDPOINTS.feeds.delete(id), { method: "DELETE" }).then<Feed>(json);
 
 export const pollFeeds = (): Promise<void> =>
-  fetch(ENDPOINTS.feeds.poll(), { method: "POST" }).then(noContent);
+  fetchWithAuth(ENDPOINTS.feeds.poll(), { method: "POST" }).then(noContent);

--- a/web/src/api/posts.ts
+++ b/web/src/api/posts.ts
@@ -5,33 +5,34 @@ import type { ListPosts } from "../types/ListPosts";
 import { ENDPOINTS, json, noContent } from "../utils/api";
 import type { ListPostArchive } from "../types/ListPostArchive";
 import type { PostArchive } from "../types/PostArchive";
+import { fetchWithAuth } from "../utils/auth";
 
 export const listPosts = (params: ListPosts): Promise<PagedResponse<Array<Post>>> =>
-  fetch(ENDPOINTS.posts.list(params)).then<PagedResponse<Array<Post>>>(json);
+  fetchWithAuth(ENDPOINTS.posts.list(params)).then<PagedResponse<Array<Post>>>(json);
 
 export const getPost = (id: number): Promise<Post> =>
-  fetch(ENDPOINTS.posts.get(id)).then<Post>(json);
+  fetchWithAuth(ENDPOINTS.posts.get(id)).then<Post>(json);
 
 export const listPostsByFeed = (feedId: number, params: ListPosts): Promise<PagedResponse<Array<Post>>> =>
-  fetch(ENDPOINTS.posts.listByFeed(feedId, params)).then<PagedResponse<Array<Post>>>(json);
+  fetchWithAuth(ENDPOINTS.posts.listByFeed(feedId, params)).then<PagedResponse<Array<Post>>>(json);
 
 export const listFavoritePosts = (page?: string): Promise<PagedResponse<Array<Post>>> =>
-  fetch(ENDPOINTS.posts.listFavorites(page)).then<PagedResponse<Array<Post>>>(json);
+  fetchWithAuth(ENDPOINTS.posts.listFavorites(page)).then<PagedResponse<Array<Post>>>(json);
 
 export const listArchivedPosts = (params: ListPostArchive): Promise<PagedResponse<Array<PostArchive>>> =>
-  fetch(ENDPOINTS.posts.listArchived(params)).then<PagedResponse<Array<PostArchive>>>(json);
+  fetchWithAuth(ENDPOINTS.posts.listArchived(params)).then<PagedResponse<Array<PostArchive>>>(json);
 
 export const getArchivedPost = (id: number): Promise<PostArchive> =>
-  fetch(ENDPOINTS.posts.getArchivedPost(id)).then<PostArchive>(json);
+  fetchWithAuth(ENDPOINTS.posts.getArchivedPost(id)).then<PostArchive>(json);
 
 export const archivePost = (id: number): Promise<PostArchive> =>
-  fetch(ENDPOINTS.posts.archive(id), { method: "POST" }).then<PostArchive>(json);
+  fetchWithAuth(ENDPOINTS.posts.archive(id), { method: "POST" }).then<PostArchive>(json);
 
 export const unarchivePost = (id: number): Promise<void> =>
-  fetch(ENDPOINTS.posts.unarchive(id), { method: "DELETE" }).then(noContent);
+  fetchWithAuth(ENDPOINTS.posts.unarchive(id), { method: "DELETE" }).then(noContent);
 
 export const updatePost = (id: number, data: UpdatePost): Promise<Post> =>
-  fetch(ENDPOINTS.posts.update(id), {
+  fetchWithAuth(ENDPOINTS.posts.update(id), {
     method: "PATCH",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(data),

--- a/web/src/api/settings.ts
+++ b/web/src/api/settings.ts
@@ -1,21 +1,21 @@
 import type { Settings } from "../types/Settings";
 import type { UpdateSettings } from "../types/UpdateSettings";
 import { ENDPOINTS, json, noContent } from "../utils/api";
+import { fetchWithAuth } from "../utils/auth";
 
 export const getSettings = (): Promise<Settings> =>
-  fetch(ENDPOINTS.settings.get()).then(json<Settings>);
+  fetchWithAuth(ENDPOINTS.settings.get()).then(json<Settings>);
 
 export const updateSettings = (body: UpdateSettings): Promise<Settings> =>
-  fetch(ENDPOINTS.settings.update(), {
+  fetchWithAuth(ENDPOINTS.settings.update(), {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
   }).then(json<Settings>);
 
 export const importOpml = (file: File): Promise<void> =>
-  fetch(ENDPOINTS.settings.import(), {
+  fetchWithAuth(ENDPOINTS.settings.import(), {
     method: "POST",
     headers: { "Content-Type": "application/xml" },
     body: file,
   }).then(noContent);
-

--- a/web/src/components/ApiKeyGate.tsx
+++ b/web/src/components/ApiKeyGate.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useRef, useState } from "react";
+import { clearApiKey, getApiKey, setApiKey, verifyApiKey } from "../utils/auth";
+
+export function ApiKeyGate({ children }: { children: React.ReactNode }) {
+  const [show, setShow] = useState(() => !getApiKey());
+  const [error, setError] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const handle = () => { clearApiKey(); setShow(true); };
+    window.addEventListener("wyrm:unauthorized", handle);
+    return () => window.removeEventListener("wyrm:unauthorized", handle);
+  }, []);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const key = inputRef.current?.value.trim();
+    if (!key) return;
+    setLoading(true);
+    setError(false);
+    const valid = await verifyApiKey(key);
+    setLoading(false);
+    if (valid) {
+      setApiKey(key);
+      setShow(false);
+    } else {
+      setError(true);
+    }
+  }
+
+  if (!show) return <>{children}</>;
+
+  return (
+    <div className="api-key-gate">
+      <form className="api-key-form" onSubmit={handleSubmit}>
+        <h2>API Key Required</h2>
+        <p>This instance of Wyrm requires an API key to access.</p>
+        <input ref={inputRef} type="password" placeholder="Enter API key" autoFocus disabled={loading} />
+        {error && <p className="api-key-error">Invalid API key.</p>}
+        <button type="submit" className="btn btn-primary" disabled={loading}>
+          {loading ? "Verifying…" : "Connect"}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/web/src/components/settings/Opml.tsx
+++ b/web/src/components/settings/Opml.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { TbDownload } from "react-icons/tb";
 import { useImportOpml } from "../../hooks/useSettings";
 import { ENDPOINTS } from "../../utils/api";
+import { fetchWithAuth } from "../../utils/auth";
 
 export function Opml() {
   const { mutate, isPending, isSuccess, isError } = useImportOpml();
@@ -54,9 +55,22 @@ export function Opml() {
       {isError && <p className="settings-status settings-status-err">Import failed.</p>}
 
       <h2 className="settings-section-title">Export</h2>
-      <a href={ENDPOINTS.settings.export()} download="wyrm.opml" className="btn btn-ghost settings-export-btn">
+      <button
+        className="btn btn-ghost settings-export-btn"
+        onClick={async () => {
+          const res = await fetchWithAuth(ENDPOINTS.settings.export());
+          if (!res.ok) return;
+          const blob = await res.blob();
+          const url = URL.createObjectURL(blob);
+          const a = document.createElement("a");
+          a.href = url;
+          a.download = "wyrm.opml";
+          a.click();
+          URL.revokeObjectURL(url);
+        }}
+      >
         <TbDownload /> Download OPML
-      </a>
+      </button>
     </div>
   );
 }

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -1,5 +1,6 @@
 import type { ListPostArchive } from "../types/ListPostArchive";
 import type { ListPosts } from "../types/ListPosts";
+import { handleUnauthorized } from "./auth";
 
 const BASE = "/api/v1";
 
@@ -48,11 +49,20 @@ export const ENDPOINTS = {
   }
 } as const;
 
+
 export async function json<T>(res: Response): Promise<T> {
+  if (res.status === 401) {
+    handleUnauthorized();
+    throw new Error("Unauthorized");
+  }
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
   return res.json();
 }
 
 export async function noContent(res: Response): Promise<void> {
+  if (res.status === 401) {
+    handleUnauthorized();
+    throw new Error("Unauthorized");
+  }
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
 }

--- a/web/src/utils/auth.ts
+++ b/web/src/utils/auth.ts
@@ -1,0 +1,30 @@
+export function getApiKey(): string | null {
+  return import.meta.env.WYRM_API_KEY || localStorage.getItem("WYRM_API_KEY");
+}
+
+export function setApiKey(key: string): void {
+  localStorage.setItem("WYRM_API_KEY", key);
+}
+
+export function clearApiKey(): void {
+  localStorage.removeItem("WYRM_API_KEY");
+}
+
+export function fetchWithAuth(url: string, init: RequestInit = {}): Promise<Response> {
+  const key = getApiKey();
+  const headers = new Headers(init.headers);
+  if (key) headers.set("Authorization", `Bearer ${key}`);
+  return fetch(url, { ...init, headers });
+}
+
+export function handleUnauthorized(): void {
+  clearApiKey();
+  window.dispatchEvent(new Event("wyrm:unauthorized"));
+}
+
+export async function verifyApiKey(key: string): Promise<boolean> {
+  const res = await fetch("/api/v1/auth/verify", {
+    headers: { "Authorization": `Bearer ${key}` },
+  });
+  return res.ok;
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -4,6 +4,7 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  envPrefix: "WYRM_",
   server: {
     proxy: {
       "/api": "http://localhost:3001",


### PR DESCRIPTION
This adds a Bearer token middleware on the backend to validate the WYRM_API_KEY against every request. Frontend prompts for the key on first load, verifies it against a dedicated `/auth/verify` endpoint, and stores it in localStorage. Setting `WYRM_API_KEY` on the frontend build skips the prompt entirely.

Also flattens the database config (database_connection, database_pool_size) so all settings are configurable via plain WYRM_* env vars without a separator.