### PR TITLE
refactor: switch API key auth to x-api-key header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,21 +186,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "actix-web-httpauth"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456348ed9dcd72a13a1f4a660449fafdecee9ac8205552e286809eb5b0b29bd3"
-dependencies = [
- "actix-utils",
- "actix-web",
- "base64",
- "futures-core",
- "futures-util",
- "log",
- "pin-project-lite",
-]
-
-[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -275,10 +260,8 @@ name = "api_routes"
 version = "0.13.0"
 dependencies = [
  "actix-web",
- "actix-web-httpauth",
  "api_api",
  "api_crud",
- "wyrm_utils",
 ]
 
 [[package]]
@@ -4015,7 +3998,6 @@ name = "wyrm_utils"
 version = "0.13.0"
 dependencies = [
  "actix-web",
- "actix-web-httpauth",
  "config",
  "deadpool",
  "diesel",

--- a/api/routes/Cargo.toml
+++ b/api/routes/Cargo.toml
@@ -9,7 +9,5 @@ rust-version.workspace = true
 
 [dependencies]
 actix-web = { workspace = true }
-actix-web-httpauth = { workspace = true }
 api_api = { path = "../api" }
 api_crud = { path = "../crud" }
-wyrm_utils = { path = "../../utils" }

--- a/api/routes/src/lib.rs
+++ b/api/routes/src/lib.rs
@@ -1,6 +1,4 @@
 use actix_web::web;
-use actix_web_httpauth::middleware::HttpAuthentication;
-use wyrm_utils::middleware::api_key_middleware;
 
 mod auth;
 mod feeds;
@@ -8,10 +6,8 @@ mod posts;
 mod settings;
 
 pub fn config(cfg: &mut web::ServiceConfig) {
-    let auth = HttpAuthentication::bearer(api_key_middleware);
     cfg.service(
         web::scope("/api/v1")
-            .wrap(auth)
             .configure(auth::config)
             .configure(posts::config)
             .configure(feeds::config)

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -1,4 +1,4 @@
-use actix_web::{App, HttpServer, dev::ServerHandle, web};
+use actix_web::{App, HttpServer, dev::ServerHandle, middleware::from_fn, web};
 use api_utils::context::WyrmContext;
 use database::{models::settings::Settings, utils::settings::RuntimeSettings};
 use std::sync::{Arc, RwLock};
@@ -10,6 +10,7 @@ use wyrm_rss::{
 use wyrm_utils::{
     config::WyrmStartupConfig,
     error::{DatabaseError, HttpServerError},
+    middleware::api_key_middleware,
     result::WyrmResult,
 };
 
@@ -69,6 +70,7 @@ fn spin_up_http_server(
         App::new()
             .app_data(ctx.clone())
             .app_data(web::Data::new(startup_conf.api_key.clone()))
+            .wrap(from_fn(api_key_middleware))
             .configure(api_routes::config)
     })
     .bind((bind, port))

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -13,7 +13,6 @@ diesel = { workspace = true }
 diesel-async = { workspace = true }
 deadpool = { workspace = true }
 actix-web = { workspace = true }
-actix-web-httpauth = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 serde = { workspace = true }

--- a/utils/src/middleware.rs
+++ b/utils/src/middleware.rs
@@ -1,17 +1,21 @@
-use actix_web::web;
-use actix_web_httpauth::extractors::bearer::BearerAuth;
+use actix_web::{Error, body::MessageBody, dev::ServiceResponse, middleware::Next, web};
 
 pub async fn api_key_middleware(
     req: actix_web::dev::ServiceRequest,
-    credentials: BearerAuth,
-) -> Result<actix_web::dev::ServiceRequest, (actix_web::Error, actix_web::dev::ServiceRequest)> {
-    let expected = req
+    next: Next<impl MessageBody>,
+) -> Result<ServiceResponse<impl MessageBody>, Error> {
+    let api_key_from_conf = req
         .app_data::<web::Data<Option<String>>>()
         .and_then(|k| k.as_deref());
 
-    match expected {
-        None => Ok(req),                                    // no key configured - pass
-        Some(key) if credentials.token() == key => Ok(req), // key matches - pass
-        _ => Err((actix_web::error::ErrorUnauthorized("Invalid api key"), req)),
+    if let Some(expected_key) = api_key_from_conf {
+        let provided = req.headers().get("x-api-key").and_then(|v| v.to_str().ok());
+
+        if provided != Some(expected_key) {
+            return Err(actix_web::error::ErrorUnauthorized("Invalid api key"));
+        }
     }
+
+    // None = auth disabled, pass through
+    next.call(req).await
 }

--- a/web/src/components/ApiKeyGate.tsx
+++ b/web/src/components/ApiKeyGate.tsx
@@ -1,19 +1,21 @@
-import { useEffect, useRef, useState } from "react";
-import { clearApiKey, getApiKey, setApiKey, verifyApiKey } from "../utils/auth";
+import { type SubmitEvent, useEffect, useRef, useState } from "react";
+import { setApiKey, verifyApiKey } from "../utils/auth";
 
 export function ApiKeyGate({ children }: { children: React.ReactNode }) {
-  const [show, setShow] = useState(() => !getApiKey());
+  // Assume access until a request comes back 401. utils/api.ts dispatches
+  // "wyrm:unauthorized" on any 401, which locks the gate.
+  const [locked, setLocked] = useState(false);
   const [error, setError] = useState(false);
   const [loading, setLoading] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    const handle = () => { clearApiKey(); setShow(true); };
+    const handle = () => setLocked(true);
     window.addEventListener("wyrm:unauthorized", handle);
     return () => window.removeEventListener("wyrm:unauthorized", handle);
   }, []);
 
-  async function handleSubmit(e: React.FormEvent) {
+  async function handleSubmit(e: SubmitEvent<HTMLFormElement>) {
     e.preventDefault();
     const key = inputRef.current?.value.trim();
     if (!key) return;
@@ -23,13 +25,13 @@ export function ApiKeyGate({ children }: { children: React.ReactNode }) {
     setLoading(false);
     if (valid) {
       setApiKey(key);
-      setShow(false);
+      setLocked(false);
     } else {
       setError(true);
     }
   }
 
-  if (!show) return <>{children}</>;
+  if (!locked) return <>{children}</>;
 
   return (
     <div className="api-key-gate">

--- a/web/src/utils/auth.ts
+++ b/web/src/utils/auth.ts
@@ -13,7 +13,7 @@ export function clearApiKey(): void {
 export function fetchWithAuth(url: string, init: RequestInit = {}): Promise<Response> {
   const key = getApiKey();
   const headers = new Headers(init.headers);
-  if (key) headers.set("Authorization", `Bearer ${key}`);
+  if (key) headers.set("x-api-key", `${key}`);
   return fetch(url, { ...init, headers });
 }
 
@@ -24,7 +24,7 @@ export function handleUnauthorized(): void {
 
 export async function verifyApiKey(key: string): Promise<boolean> {
   const res = await fetch("/api/v1/auth/verify", {
-    headers: { "Authorization": `Bearer ${key}` },
+    headers: { "x-api-key": `${key}` },
   });
   return res.ok;
 }


### PR DESCRIPTION
This change replaces Authorization: Bearer based API auth with a `x-api-key` header, which allows dropping the `actix-web-httpauth` depencency. It only results in 401 IF the user configured an API key, otherwise it passes through the request. This differs from previous approach which would always return 401 is a request didn't include an Authorizatin header. This allows the UI to only show the api key gate when the backend returns a 401.