### PR TITLE
refactor: split post list components

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 import "./App.css";
 import { ApiKeyGate } from "./components/ApiKeyGate";
 import { ArchiveList } from "./components/ArchiveList";
+import { FavoritePostList } from "./components/FavoritePostList";
 import { PostList } from "./components/PostList";
 import { ThemeProvider } from "./context/ThemeProvider";
 import { AppLayout } from "./pages/AppLayout";
@@ -25,8 +26,8 @@ export default function App() {
                 <Route path="/feeds/posts/:postId" element={<PostList />} />
                 <Route path="/feeds/:feedId" element={<PostList />} />
                 <Route path="/feeds/:feedId/posts/:postId" element={<PostList />} />
-                <Route path="/favorites" element={<PostList />} />
-                <Route path="/favorites/:postId" element={<PostList />} />
+                <Route path="/favorites" element={<FavoritePostList />} />
+                <Route path="/favorites/:postId" element={<FavoritePostList />} />
                 <Route path="/archive" element={<ArchiveList />} />
                 <Route path="/archive/:postId" element={<ArchiveList />} />
               </Route>

--- a/web/src/cache/posts.ts
+++ b/web/src/cache/posts.ts
@@ -1,0 +1,108 @@
+/**
+ * Post cache: we use TanStack's QueryClient posts fetched under a query key.
+ *
+ * We store every fetched result under a "query key" (an array like 
+ * `["posts", "list", { tag, search }]`). Components read from those
+ * cached entries, so when the user changes a post (reads it, favorites it,
+ * archives it) we can either edit the cached copy directly so the change shows
+ * instantly, or mark the entry stale so React Query refetches it. The refetch
+ * isn't manual: the component reading that query (via `useQuery` /
+ * `useInfiniteQuery`) is subscribed to it, so when we invalidate the entry that
+ * hook re-runs its own fetch. 
+ * This file centralizes all of that, so the mutation hooks stay thin and no
+ * component has to know how the cache works.
+ *
+ * The same post can live in several cached entries at once — the all-posts list,
+ * a single feed's list, the favorites list, the archived list, plus its own
+ * detail entry. A change has to be reflected in all of them.
+ *
+ * Structure:
+ *  - `postKeys`  — the single source of truth for every query key. Each entry
+ *                  is either a `*Prefix` (matches *every* variant of a list,
+ *                  e.g. all tag/search combos — used for bulk updates) or a
+ *                  function that builds the exact key one query is stored under.
+ *  - patch helpers (`patchPostInPages`, `patchPostInLists`) — edit the cached
+ *                  copies in place so the UI updates without a request fired.
+ *  - intent helpers (`setPostArchived`, `applyPostEdit`) — what the mutation
+ *                  hooks actually call; each describes one user action and does
+ *                  the right mix of patching (for changed fields) and
+ *                  invalidating (when a list gains or loses the post).
+ *
+ * Rule of thumb: patch when a post's *fields* change but it stays in the same
+ * lists; invalidate (refetch) when a list's *membership* changes, because a
+ * patch can edit existing rows but can't add or remove them.
+ */
+import type { InfiniteData, QueryClient } from "@tanstack/react-query";
+import type { Post } from "../types/Post";
+import type { PagedResponse } from "../types/PagedResponse";
+
+export const postKeys = {
+  all: ["posts"] as const,
+
+  // Prefixes match every variant of a list (any tag/search) for bulk cache updates;
+  // the functions below build the exact key a given query is cached under.
+  listPrefix: ["posts", "list"] as const,
+  listed: (tag?: string, search?: string) => ["posts", "list", { tag, search }] as const,
+
+  feedPrefix: ["posts", "feed"] as const,
+  byFeed: (feedId: number) => ["posts", "feed", feedId] as const,
+
+  favoritesPrefix: ["posts", "favorites"] as const,
+  favorites: (search?: string) => ["posts", "favorites", { search }] as const,
+
+  archivedPrefix: ["posts", "archived"] as const,
+  archived: (search?: string, tag?: string) => ["posts", "archived", { search, tag }] as const,
+
+  detail: (id: number) => ["posts", id] as const,
+  archiveDetail: (id: number) => ["posts", "archive", id] as const,
+};
+
+export type PostPages = InfiniteData<PagedResponse<Post[]>> | undefined;
+
+export function patchPostInPages(cached: PostPages, patch: (post: Post) => Post): PostPages {
+  if (!cached) return cached;
+  return {
+    ...cached,
+    pages: cached.pages.map((page) => ({
+      ...page,
+      items: page.items.map(patch),
+    })),
+  };
+}
+
+// Update the post with `postId` wherever it appears in the cached lists
+// (all-posts, by-feed, favorites). Pass a full Post to replace it
+function patchPostInLists(queryClient: QueryClient, postId: number, changes: Partial<Post>) {
+  const apply = (post: Post) => (post.id === postId ? { ...post, ...changes } : post);
+  for (const queryKey of [postKeys.listPrefix, postKeys.feedPrefix, postKeys.favoritesPrefix]) {
+    queryClient.setQueriesData({ queryKey }, (cached: PostPages) => patchPostInPages(cached, apply));
+  }
+}
+
+// Reflects an archive/unarchive in the cache: flips is_archived everywhere the
+// post is cached, and refreshes the archived list.
+export function setPostArchived(queryClient: QueryClient, postId: number, isArchived: boolean) {
+  queryClient.setQueryData(postKeys.detail(postId), (cached: Post | undefined) =>
+    cached ? { ...cached, is_archived: isArchived } : cached,
+  );
+  patchPostInLists(queryClient, postId, { is_archived: isArchived });
+  queryClient.invalidateQueries({ queryKey: postKeys.archivedPrefix });
+
+  // a cached single archived-post is only valid while it's archived
+  if (!isArchived) {
+    queryClient.removeQueries({ queryKey: postKeys.archiveDetail(postId) });
+  }
+}
+
+// Reflects an edited post (title/read/favorite) across every list it appears in
+// — all-posts, by-feed, and favorites.
+export function applyPostEdit(queryClient: QueryClient, post: Post, favoriteChanged: boolean) {
+  queryClient.setQueryData(postKeys.detail(post.id), post);
+  patchPostInLists(queryClient, post.id, post);
+
+  // Favoriting adds the post to the favorites list; unfavoriting removes it.
+  // Patching only updates rows already there, so refetch to add/drop the post.
+  if (favoriteChanged) {
+    queryClient.invalidateQueries({ queryKey: postKeys.favoritesPrefix });
+  }
+}

--- a/web/src/components/AddFeedForm.tsx
+++ b/web/src/components/AddFeedForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { type SubmitEvent, useState } from "react";
 import { useCreateFeed } from "../hooks/useFeeds";
 
 interface Props {
@@ -22,7 +22,7 @@ export function AddFeedForm({ onClose }: Props) {
     setUrlFilters(urlFilters.filter((_, i) => i !== index));
   }
 
-  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+  function handleSubmit(e: SubmitEvent<HTMLFormElement>) {
     e.preventDefault();
     create.mutate(
       {

--- a/web/src/components/ArchiveItem.tsx
+++ b/web/src/components/ArchiveItem.tsx
@@ -2,7 +2,7 @@ import { memo } from "react";
 import { Link } from "react-router-dom";
 import { TbArchiveOff } from "react-icons/tb";
 import type { PostArchive } from "../types/PostArchive";
-import { useUnarchivePost } from "../hooks/usePosts";
+import { useUnarchivePost } from "../hooks/usePostMutations";
 
 interface Props {
   archive: PostArchive;

--- a/web/src/components/ArchiveList.tsx
+++ b/web/src/components/ArchiveList.tsx
@@ -1,75 +1,47 @@
-import { useEffect, useMemo, useState } from "react";
+import { useState } from "react";
 import { useOutletContext, useParams } from "react-router-dom";
-import { useArchivedPosts } from "../hooks/usePosts";
+import { useArchivedPosts, useArchiveTags } from "../hooks/usePosts";
+import { useDebouncedSearch } from "../hooks/useDebouncedSearch";
+import { useOpenPostFromRoute } from "../hooks/useOpenPostFromRoute";
+import { useFlattenedPages } from "../hooks/useFlattenedPages";
 import { ArchiveItem } from "./ArchiveItem";
+import { PostsToolbar } from "./PostsToolbar";
+import { PostsTagChips } from "./PostsTagChips";
 import { VirtualGroupedList } from "./VirtualGroupedList";
 import type { ReaderOutletContext } from "../pages/ReaderPage";
 
 export function ArchiveList() {
   const { activePostId, onOpenPost } = useOutletContext<ReaderOutletContext>();
+
   const { postId } = useParams();
 
-  const [search, setSearch] = useState("");
-  const [debouncedSearch, setDebouncedSearch] = useState("");
   const [activeTag, setActiveTag] = useState<string | undefined>(undefined);
 
-  // Delay search query until the user stops typing
-  useEffect(() => {
-    const timer = setTimeout(() => setDebouncedSearch(search), 300);
-    return () => clearTimeout(timer);
-  }, [search]);
+  const { search, setSearch, debouncedSearch } = useDebouncedSearch();
 
-  // Data kept in cache for tag chip discovery.
-  // PostList doesn't need this because tags are derived from feeds.
-  const { data: cachedData } = useArchivedPosts();
-  const { data, isLoading, hasNextPage, fetchNextPage, isFetchingNextPage } =
-    useArchivedPosts(debouncedSearch || undefined, activeTag);
+  const {
+    data,
+    isLoading,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage
+  } = useArchivedPosts({ tag: activeTag, search: debouncedSearch || undefined });
 
-  useEffect(() => {
-    if (postId) onOpenPost(Number(postId));
-  }, [postId, onOpenPost]);
+  useOpenPostFromRoute(postId, onOpenPost);
 
-  const items = useMemo(
-    () => data?.pages.flatMap((p) => p.items),
-    [data]
-  );
-
-  const { tagMap, tagKeys } = useMemo(() => {
-    const tagMap = new Map<string, string | undefined>();
-    for (const page of cachedData?.pages ?? []) {
-      for (const item of page.items) {
-        if (item.tag) tagMap.set(item.tag, item.tag_color ?? undefined);
-      }
-    }
-    return { tagMap, tagKeys: [...tagMap.keys()] };
-  }, [cachedData]);
+  const archives = useFlattenedPages(data);
+  const tags = useArchiveTags();
 
   return (
     <div className="pane pane-posts">
-      <div className="posts-toolbar">
-        <input
-          className="posts-search"
-          placeholder="Search archive…"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-        />
-      </div>
-      {tagKeys.length > 0 && (
-        <div className="posts-tags">
-          {tagKeys.map((tag) => (
-            <button
-              key={tag}
-              className={`posts-tag-chip${activeTag === tag ? " active" : ""}`}
-              style={{ "--tag-color": tagMap.get(tag) ?? "var(--text)" } as React.CSSProperties}
-              onClick={() => setActiveTag((prev) => (prev === tag ? undefined : tag))}
-            >
-              {tag}
-            </button>
-          ))}
-        </div>
-      )}
+      <PostsToolbar value={search} onChange={setSearch} placeholder="Search archive…" />
+      <PostsTagChips
+        tags={tags}
+        activeTag={activeTag}
+        onToggle={(tag) => setActiveTag((prev) => (prev === tag ? undefined : tag))}
+      />
       <VirtualGroupedList
-        items={items}
+        items={archives}
         isLoading={isLoading}
         hasNextPage={hasNextPage}
         fetchNextPage={fetchNextPage}

--- a/web/src/components/ArchiveReader.tsx
+++ b/web/src/components/ArchiveReader.tsx
@@ -1,5 +1,6 @@
 import { TbArchiveOff } from "react-icons/tb";
-import { useArchivedPost, useUnarchivePost } from "../hooks/usePosts";
+import { useArchivedPost } from "../hooks/usePosts";
+import { useUnarchivePost } from "../hooks/usePostMutations";
 import { formatDate } from "../utils/utils";
 import { ReaderPane } from "./ReaderPane";
 

--- a/web/src/components/FavoritePostList.tsx
+++ b/web/src/components/FavoritePostList.tsx
@@ -1,0 +1,53 @@
+import { useOutletContext, useParams } from "react-router-dom";
+import { useFavoritePosts } from "../hooks/usePosts";
+import { useFeeds } from "../hooks/useFeeds";
+import { useDebouncedSearch } from "../hooks/useDebouncedSearch";
+import { useOpenPostFromRoute } from "../hooks/useOpenPostFromRoute";
+import { useFeedMap } from "../hooks/useFeedMap";
+import { useFlattenedPages } from "../hooks/useFlattenedPages";
+import { PostItem } from "./PostItem";
+import { PostsToolbar } from "./PostsToolbar";
+import { VirtualGroupedList } from "./VirtualGroupedList";
+import type { ReaderOutletContext } from "../pages/ReaderPage";
+import { postPath } from "../utils/posts";
+
+export function FavoritePostList() {
+  const { activePostId, onOpenPost } = useOutletContext<ReaderOutletContext>();
+
+  const { postId } = useParams();
+
+  const { data: feeds } = useFeeds();
+
+  const { search, setSearch, debouncedSearch } = useDebouncedSearch();
+
+  const { data, isLoading, hasNextPage, fetchNextPage, isFetchingNextPage } =
+    useFavoritePosts(debouncedSearch || undefined);
+
+  useOpenPostFromRoute(postId, onOpenPost);
+
+  const feedMap = useFeedMap(feeds);
+
+  const posts = useFlattenedPages(data);
+
+  return (
+    <div className="pane pane-posts">
+      <PostsToolbar value={search} onChange={setSearch} placeholder="Search favorites…" />
+      <VirtualGroupedList
+        items={posts}
+        isLoading={isLoading}
+        hasNextPage={hasNextPage}
+        fetchNextPage={fetchNextPage}
+        isFetchingNextPage={isFetchingNextPage}
+        emptyMessage="No favorites yet"
+        renderItem={(post) => (
+          <PostItem
+            post={post}
+            to={postPath(post, undefined, true)}
+            active={activePostId === post.id}
+            feed={feedMap.get(post.feed_id)}
+          />
+        )}
+      />
+    </div>
+  );
+}

--- a/web/src/components/PostItem.tsx
+++ b/web/src/components/PostItem.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import { HiMail, HiMailOpen } from "react-icons/hi";
 import { TbArchive, TbArchiveOff, TbStar, TbStarFilled } from "react-icons/tb";
 import type { Post } from "../types/Post";
-import { useArchivePost, useUnarchivePost, useUpdatePost } from "../hooks/usePosts";
+import { useArchivePost, useUnarchivePost, useUpdatePost } from "../hooks/usePostMutations";
 import { useSettings } from "../hooks/useSettings";
 import { initials } from "../utils/posts";
 

--- a/web/src/components/PostList.tsx
+++ b/web/src/components/PostList.tsx
@@ -1,9 +1,15 @@
-import { useEffect, useMemo, useState } from "react";
-import { useLocation, useOutletContext, useParams } from "react-router-dom";
+import { useMemo, useState } from "react";
+import { useOutletContext, useParams } from "react-router-dom";
 import { TbRefresh } from "react-icons/tb";
-import { useFavoritePosts, usePosts } from "../hooks/usePosts";
-import { useFeeds, usePollFeeds } from "../hooks/useFeeds";
-import { PostItem, type FeedMeta } from "./PostItem";
+import { usePosts } from "../hooks/usePosts";
+import { useFeeds, usePollFeeds, useFeedTags } from "../hooks/useFeeds";
+import { useDebouncedSearch } from "../hooks/useDebouncedSearch";
+import { useOpenPostFromRoute } from "../hooks/useOpenPostFromRoute";
+import { useFeedMap } from "../hooks/useFeedMap";
+import { useFlattenedPages } from "../hooks/useFlattenedPages";
+import { PostItem } from "./PostItem";
+import { PostsToolbar } from "./PostsToolbar";
+import { PostsTagChips } from "./PostsTagChips";
 import { VirtualGroupedList } from "./VirtualGroupedList";
 import type { ReaderOutletContext } from "../pages/ReaderPage";
 import { postPath } from "../utils/posts";
@@ -11,90 +17,58 @@ import { postPath } from "../utils/posts";
 export function PostList() {
   const { excludedFeeds, activePostId, onOpenPost } = useOutletContext<ReaderOutletContext>();
 
-  const { pathname } = useLocation();
-  const isFavorites = pathname.startsWith("/favorites");
-
   const { feedId, postId } = useParams();
+
   const feedIdNum = feedId ? Number(feedId) : undefined;
 
   const { data: feeds } = useFeeds();
-  const pollFeeds = usePollFeeds();
-  const favoritePosts = useFavoritePosts();
 
-  const [search, setSearch] = useState("");
-  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const pollFeeds = usePollFeeds();
+
+  const { search, setSearch, debouncedSearch } = useDebouncedSearch();
 
   const [activeTag, setActiveTag] = useState<string | undefined>(undefined);
 
   // Reset activeTag on navigation. setState during render (vs. useEffect) avoids rendering once
   // with a stale tag before the reset kicks in.
   const [prevFeedId, setPrevFeedId] = useState(feedId);
-  const [prevIsFavorites, setPrevIsFavorites] = useState(isFavorites);
-  if (prevFeedId !== feedId || prevIsFavorites !== isFavorites) {
+  if (prevFeedId !== feedId) {
     setPrevFeedId(feedId);
-    setPrevIsFavorites(isFavorites);
     setActiveTag(undefined);
   }
 
-  // Delay search query until the user stops typing
-  useEffect(() => {
-    const timer = setTimeout(() => setDebouncedSearch(search), 300);
-    return () => clearTimeout(timer);
-  }, [search]);
+  const showTagChips = !feedIdNum;
 
-  const showTagChips = !feedIdNum && !isFavorites;
-  const feedPosts = usePosts(feedIdNum, showTagChips ? activeTag : undefined, debouncedSearch || undefined);
   const {
     data,
     isLoading,
     hasNextPage,
     fetchNextPage,
     isFetchingNextPage,
-    isRefetching,
-  } = isFavorites ? favoritePosts : feedPosts;
+    isRefetching }
+    = usePosts({
+      feedId: feedIdNum,
+      tag: showTagChips ? activeTag : undefined,
+      search: debouncedSearch || undefined
+    });
 
-  // Keep the same FeedMeta object references between renders so React.memo on PostItem can bail out
-  const feedMap = useMemo(
+  useOpenPostFromRoute(postId, onOpenPost);
+
+  const feedMap = useFeedMap(feeds);
+  const tags = useFeedTags(feeds);
+
+  const allPosts = useFlattenedPages(data);
+  const posts = useMemo(
     () =>
-      new Map(
-        (feeds ?? []).map((f): [number, FeedMeta] => [
-          f.id,
-          { name: f.title, tag: f.tag, tagColor: f.tag_color },
-        ])
+      allPosts?.filter(
+        (p) => feedIdNum !== undefined || !excludedFeeds.has(p.feed_id)
       ),
-    [feeds]
+    [allPosts, excludedFeeds, feedIdNum]
   );
-
-  // Same — avoid recreating tag arrays on every render
-  const { tagMap, tags } = useMemo(() => {
-    const tagMap = new Map(
-      (feeds ?? [])
-        .filter((f) => f.tag !== undefined)
-        .map((f) => [f.tag!, f.tag_color])
-    );
-    return { tagMap, tags: [...tagMap.keys()] };
-  }, [feeds]);
-
-  useEffect(() => {
-    if (postId) onOpenPost(Number(postId));
-  }, [postId, onOpenPost]);
-
-  const items = useMemo(() => {
-    const posts = data?.pages.flatMap((p) => p.items);
-    return posts?.filter(
-      (p) => isFavorites || feedIdNum !== undefined || !excludedFeeds.has(p.feed_id)
-    );
-  }, [data, excludedFeeds, isFavorites, feedIdNum]);
 
   return (
     <div className="pane pane-posts">
-      <div className="posts-toolbar">
-        <input
-          className="posts-search"
-          placeholder="Search posts…"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-        />
+      <PostsToolbar value={search} onChange={setSearch}>
         <button
           className="posts-refresh-btn"
           onClick={() => pollFeeds.mutate()}
@@ -103,32 +77,25 @@ export function PostList() {
         >
           <TbRefresh className={pollFeeds.isPending || isRefetching ? "spinning" : ""} />
         </button>
-      </div>
-      {showTagChips && tags.length > 0 && (
-        <div className="posts-tags">
-          {tags.map((tag) => (
-            <button
-              key={tag}
-              className={`posts-tag-chip${activeTag === tag ? " active" : ""}`}
-              style={{ "--tag-color": tagMap.get(tag) ?? "var(--text)" } as React.CSSProperties}
-              onClick={() => setActiveTag((prev) => (prev === tag ? undefined : tag))}
-            >
-              {tag}
-            </button>
-          ))}
-        </div>
+      </PostsToolbar>
+      {showTagChips && (
+        <PostsTagChips
+          tags={tags}
+          activeTag={activeTag}
+          onToggle={(tag) => setActiveTag((prev) => (prev === tag ? undefined : tag))}
+        />
       )}
       <VirtualGroupedList
-        items={items}
+        items={posts}
         isLoading={isLoading}
         hasNextPage={hasNextPage}
         fetchNextPage={fetchNextPage}
         isFetchingNextPage={isFetchingNextPage}
-        emptyMessage={isFavorites ? "No favorites yet" : "No posts"}
+        emptyMessage="No posts"
         renderItem={(post) => (
           <PostItem
             post={post}
-            to={postPath(post, feedIdNum, isFavorites)}
+            to={postPath(post, feedIdNum, false)}
             active={activePostId === post.id}
             feed={feedIdNum === undefined ? feedMap.get(post.feed_id) : undefined}
           />

--- a/web/src/components/PostReader.tsx
+++ b/web/src/components/PostReader.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef } from "react";
 import YouTube from "react-youtube";
 import { TbArchive, TbArchiveOff, TbStar, TbStarFilled } from "react-icons/tb";
-import { useArchivePost, usePost, useUnarchivePost, useUpdatePost } from "../hooks/usePosts";
+import { usePost } from "../hooks/usePosts";
+import { useArchivePost, useUnarchivePost, useUpdatePost } from "../hooks/usePostMutations";
 import { useSettings } from "../hooks/useSettings";
 import { extractYouTubeId, formatDate } from "../utils/utils";
 import { ReaderPane } from "./ReaderPane";

--- a/web/src/components/PostsTagChips.tsx
+++ b/web/src/components/PostsTagChips.tsx
@@ -1,0 +1,28 @@
+export interface Tag {
+  name: string;
+  color?: string;
+}
+
+interface Props {
+  tags: Tag[];
+  activeTag: string | undefined;
+  onToggle: (tag: string) => void;
+}
+
+export function PostsTagChips({ tags, activeTag, onToggle }: Props) {
+  if (tags.length === 0) return null;
+  return (
+    <div className="posts-tags">
+      {tags.map(({ name, color }) => (
+        <button
+          key={name}
+          className={`posts-tag-chip${activeTag === name ? " active" : ""}`}
+          style={{ "--tag-color": color ?? "var(--text)" } as React.CSSProperties}
+          onClick={() => onToggle(name)}
+        >
+          {name}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/web/src/components/PostsToolbar.tsx
+++ b/web/src/components/PostsToolbar.tsx
@@ -1,0 +1,21 @@
+interface Props {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  /** More actions displayed after the search input, e.g. a refresh button. */
+  children?: React.ReactNode;
+}
+
+export function PostsToolbar({ value, onChange, placeholder = "Search posts…", children }: Props) {
+  return (
+    <div className="posts-toolbar">
+      <input
+        className="posts-search"
+        placeholder={placeholder}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      />
+      {children}
+    </div>
+  );
+}

--- a/web/src/hooks/useDebouncedSearch.ts
+++ b/web/src/hooks/useDebouncedSearch.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from "react";
+
+export function useDebouncedSearch(delay = 300) {
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+
+  // Delay the query until the user stops typing
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedSearch(search), delay);
+    return () => clearTimeout(timer);
+  }, [search, delay]);
+
+  return { search, setSearch, debouncedSearch };
+}

--- a/web/src/hooks/useFeedMap.ts
+++ b/web/src/hooks/useFeedMap.ts
@@ -1,0 +1,20 @@
+import { useMemo } from "react";
+import type { Feed } from "../types/Feed";
+import type { FeedMeta } from "../components/PostItem";
+
+/**
+ * Maps feed id - display metadata for post rows. Memoised so the FeedMeta
+ * object references stay stable between renders and React.memo on PostItem can bail out
+ */
+export function useFeedMap(feeds: Feed[] | undefined): Map<number, FeedMeta> {
+  return useMemo(
+    () =>
+      new Map(
+        (feeds ?? []).map((f): [number, FeedMeta] => [
+          f.id,
+          { name: f.title, tag: f.tag, tagColor: f.tag_color },
+        ])
+      ),
+    [feeds]
+  );
+}

--- a/web/src/hooks/useFeeds.ts
+++ b/web/src/hooks/useFeeds.ts
@@ -1,8 +1,11 @@
+import { useMemo } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFeed, deleteFeed, getFeeds, pollFeeds, updateFeed } from "../api/feeds";
-import { postKeys } from "./usePosts";
+import { postKeys } from "../cache/posts";
 import type { CreateFeed } from "../types/CreateFeed";
 import type { UpdateFeed } from "../types/UpdateFeed";
+import type { Feed } from "../types/Feed";
+import type { Tag } from "../components/PostsTagChips";
 
 export const feedKeys = {
   all: ["feeds"] as const,
@@ -10,6 +13,17 @@ export const feedKeys = {
 
 export function useFeeds() {
   return useQuery({ queryKey: feedKeys.all, queryFn: getFeeds });
+}
+
+/** Extracts tags from feeds into a Tag array */
+export function useFeedTags(feeds: Feed[] | undefined): Tag[] {
+  return useMemo(
+    () =>
+      (feeds ?? [])
+        .filter((f) => f.tag !== undefined)
+        .map((f) => ({ name: f.tag!, color: f.tag_color })),
+    [feeds]
+  );
 }
 
 export function useCreateFeed() {

--- a/web/src/hooks/useFlattenedPages.ts
+++ b/web/src/hooks/useFlattenedPages.ts
@@ -1,0 +1,10 @@
+import { useMemo } from "react";
+import type { InfiniteData } from "@tanstack/react-query";
+import type { PagedResponse } from "../types/PagedResponse";
+
+/** Flattens the pages of an infinite query into a single list. */
+export function useFlattenedPages<T>(
+  data: InfiniteData<PagedResponse<T[]>> | undefined
+): T[] | undefined {
+  return useMemo(() => data?.pages.flatMap((p) => p.items), [data]);
+}

--- a/web/src/hooks/useOpenPostFromRoute.ts
+++ b/web/src/hooks/useOpenPostFromRoute.ts
@@ -1,0 +1,11 @@
+import { useEffect } from "react";
+
+/** Open the post named by the `:postId` route param, if one is present. */
+export function useOpenPostFromRoute(
+  postId: string | undefined,
+  onOpenPost: (id: number) => void
+) {
+  useEffect(() => {
+    if (postId) onOpenPost(Number(postId));
+  }, [postId, onOpenPost]);
+}

--- a/web/src/hooks/usePostMutations.ts
+++ b/web/src/hooks/usePostMutations.ts
@@ -1,0 +1,46 @@
+/**
+ * Mutations for changing a post (archive, unarchive, edit read/favorite).
+ *
+ * Each mutation does two things: `mutationFn` sends the change to the server,
+ * and `onSuccess` reconciles the local cache so the UI reflects it without
+ * waiting for a fresh load. The list hooks (`useFavoritePosts`, etc.) only
+ * fetch when they mount or when their cache entry is invalidated — they don't
+ * know a post changed — so this `onSuccess` step is the only thing that keeps
+ * the already-rendered lists in sync after an action.
+ *
+ * The actual cache reconciliation lives in `cache/posts.ts` (`setPostArchived`,
+ * `applyPostEdit`); see that file for the patch-vs-invalidate logic. In
+ * short: a field change (e.g. mark-as-read) patches the cached rows in place,
+ * while a change to which list a post belongs to (e.g. (un)favorite) invalidates
+ * that list so the subscribed hook refetches and the row appears/disappears.
+ */
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { archivePost, unarchivePost, updatePost } from "../api/posts";
+import type { UpdatePost } from "../types/UpdatePost";
+import { setPostArchived, applyPostEdit } from "../cache/posts";
+
+export function useArchivePost() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: archivePost,
+    onSuccess: (archive) => setPostArchived(queryClient, archive.id, true),
+  });
+}
+
+export function useUnarchivePost() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: unarchivePost,
+    onSuccess: (_, postId) => setPostArchived(queryClient, postId, false),
+  });
+}
+
+export function useUpdatePost() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, ...data }: { id: number } & UpdatePost) => updatePost(id, data),
+    // is_favorite is null when this edit didn't touch the favorite flag (e.g. a
+    // read toggle); a non-null value means the user (un)favorited the post.
+    onSuccess: (post, variables) => applyPostEdit(queryClient, post, variables.is_favorite !== null),
+  });
+}

--- a/web/src/hooks/usePosts.ts
+++ b/web/src/hooks/usePosts.ts
@@ -1,66 +1,30 @@
+import { useMemo } from "react";
 import {
+  infiniteQueryOptions,
   useInfiniteQuery,
-  useMutation,
   useQuery,
-  useQueryClient,
-  type InfiniteData,
+  type QueryKey,
 } from "@tanstack/react-query";
-import { archivePost, getArchivedPost, listArchivedPosts, listFavoritePosts, getPost, listPosts, listPostsByFeed, unarchivePost, updatePost } from "../api/posts";
-import type { Post } from "../types/Post";
-import type { PostArchive } from "../types/PostArchive";
+import { getArchivedPost, getPost, listArchivedPosts, listFavoritePosts, listPosts, listPostsByFeed } from "../api/posts";
 import type { PagedResponse } from "../types/PagedResponse";
-import type { UpdatePost } from "../types/UpdatePost";
+import type { Tag } from "../components/PostsTagChips";
+import { postKeys } from "../cache/posts";
 
-type PostPages = InfiniteData<PagedResponse<Post[]>> | undefined;
+type PostsQuery = { feedId?: number; tag?: string; search?: string };
 
-function patchPostInPages(cached: PostPages, patch: (post: Post) => Post): PostPages {
-  if (!cached) return cached;
-  return {
-    ...cached,
-    pages: cached.pages.map((page) => ({
-      ...page,
-      items: page.items.map(patch),
-    })),
-  };
-}
+type ArchivedQuery = { search?: string; tag?: string };
 
-export const postKeys = {
-  all: ["posts"] as const,
-  listed: (tag?: string, search?: string) => ["posts", "list", { tag, search }] as const,
-  byFeed: (feedId: number) => ["posts", "feed", feedId] as const,
-  favorites: (search?: string) => ["posts", "favorites", { search }] as const,
-  archived: (search?: string, tag?: string) => ["posts", "archived", { search, tag }] as const,
-  detail: (id: number) => ["posts", id] as const,
-};
-
-export function usePosts(feedId?: number, tag?: string, search?: string) {
-  return useInfiniteQuery({
-    queryKey: feedId ? postKeys.byFeed(feedId) : postKeys.listed(tag, search),
-    queryFn: ({ pageParam }) =>
-      feedId ? listPostsByFeed(feedId, { page: pageParam, search }) : listPosts({ page: pageParam, tag, search }),
+// Shared config for the cursor-paginated post lists: same paging behaviour,
+// differing only by cache key and which endpoint fetches a page.
+function infinitePostsQuery<T>(
+  queryKey: QueryKey,
+  fetchPage: (page?: string) => Promise<PagedResponse<T[]>>,
+) {
+  return infiniteQueryOptions({
+    queryKey,
+    queryFn: ({ pageParam }) => fetchPage(pageParam),
     initialPageParam: undefined as string | undefined,
-    getNextPageParam: (lastPage): string | undefined =>
-      lastPage.next_page ?? undefined,
-  });
-}
-
-export function useFavoritePosts(search?: string) {
-  return useInfiniteQuery({
-    queryKey: postKeys.favorites(search),
-    queryFn: ({ pageParam }) => listFavoritePosts({ page: pageParam, search }),
-    initialPageParam: undefined as string | undefined,
-    getNextPageParam: (lastPage): string | undefined =>
-      lastPage.next_page ?? undefined,
-  });
-}
-
-export function useArchivedPosts(search?: string, tag?: string) {
-  return useInfiniteQuery({
-    queryKey: postKeys.archived(search, tag),
-    queryFn: ({ pageParam }) => listArchivedPosts({ page: pageParam, search, tag }),
-    initialPageParam: undefined as string | undefined,
-    getNextPageParam: (lastPage): string | undefined =>
-      lastPage.next_page ?? undefined,
+    getNextPageParam: (lastPage) => lastPage.next_page ?? undefined,
   });
 }
 
@@ -72,61 +36,46 @@ export function usePost(id?: number) {
   });
 }
 
+export function usePosts({ feedId, tag, search }: PostsQuery = {}) {
+  return useInfiniteQuery(
+    feedId
+      ? infinitePostsQuery(postKeys.byFeed(feedId), (page) => listPostsByFeed(feedId, { page, search }))
+      : infinitePostsQuery(postKeys.listed(tag, search), (page) => listPosts({ page, tag, search })),
+  );
+}
+
+export function useFavoritePosts(search?: string) {
+  return useInfiniteQuery(
+    infinitePostsQuery(postKeys.favorites(search), (page) => listFavoritePosts({ page, search })),
+  );
+}
+
 export function useArchivedPost(id?: number) {
   return useQuery({
-    queryKey: ["posts", "archive", id!],
+    queryKey: postKeys.archiveDetail(id!),
     queryFn: () => getArchivedPost(id!),
     enabled: id !== undefined,
   });
 }
 
-export function useArchivePost() {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: (postId: number) => archivePost(postId),
-    onSuccess: (archive: PostArchive) => {
-      const patch = (p: Post) => p.id === archive.id ? { ...p, is_archived: true } : p;
-      queryClient.setQueryData(postKeys.detail(archive.id), (cached: Post | undefined) =>
-        cached ? { ...cached, is_archived: true } : cached,
-      );
-      queryClient.setQueriesData({ queryKey: ["posts", "list"] }, (cached: PostPages) => patchPostInPages(cached, patch));
-      queryClient.setQueriesData({ queryKey: ["posts", "feed"] }, (cached: PostPages) => patchPostInPages(cached, patch));
-      queryClient.setQueriesData({ queryKey: ["posts", "favorites"] }, (cached: PostPages) => patchPostInPages(cached, patch));
-      queryClient.invalidateQueries({ queryKey: ["posts", "archived"] });
-    },
-  });
+export function useArchivedPosts({ search, tag }: ArchivedQuery = {}) {
+  return useInfiniteQuery(
+    infinitePostsQuery(postKeys.archived(search, tag), (page) => listArchivedPosts({ page, search, tag })),
+  );
 }
 
-export function useUnarchivePost() {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: (postId: number) => unarchivePost(postId),
-    onSuccess: (_, postId: number) => {
-      const patch = (p: Post) => p.id === postId ? { ...p, is_archived: false } : p;
-      queryClient.setQueryData(postKeys.detail(postId), (cached: Post | undefined) =>
-        cached ? { ...cached, is_archived: false } : cached,
-      );
-      queryClient.setQueriesData({ queryKey: ["posts", "list"] }, (cached: PostPages) => patchPostInPages(cached, patch));
-      queryClient.setQueriesData({ queryKey: ["posts", "feed"] }, (cached: PostPages) => patchPostInPages(cached, patch));
-      queryClient.setQueriesData({ queryKey: ["posts", "favorites"] }, (cached: PostPages) => patchPostInPages(cached, patch));
-      queryClient.invalidateQueries({ queryKey: ["posts", "archived"] });
-      queryClient.removeQueries({ queryKey: ["posts", "archive", postId] });
-    },
-  });
-}
-
-export function useUpdatePost() {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: ({ id, ...data }: { id: number } & UpdatePost) => updatePost(id, data),
-    onSuccess: (post: Post, variables) => {
-      const patch = (p: Post) => p.id === post.id ? post : p;
-      queryClient.setQueryData(postKeys.detail(post.id), post);
-      queryClient.setQueriesData({ queryKey: ["posts", "list"] }, (cached: PostPages) => patchPostInPages(cached, patch));
-      queryClient.setQueryData(postKeys.byFeed(post.feed_id), (cached: PostPages) => patchPostInPages(cached, patch));
-      if (variables.is_favorite !== null) {
-        queryClient.invalidateQueries({ queryKey: ["posts", "favorites"] });
+/** Extracts tags from archive posts into a Tag array */
+export function useArchiveTags(): Tag[] {
+  const { data } = useArchivedPosts();
+  return useMemo(() => {
+    const map = new Map<string, string | undefined>();
+    for (const page of data?.pages ?? []) {
+      for (const item of page.items) {
+        if (item.tag) map.set(item.tag, item.tag_color ?? undefined);
       }
-    },
-  });
+    }
+    return [...map].map(([name, color]) => ({ name, color }));
+  }, [data]);
 }
+
+


### PR DESCRIPTION
Separated out from post list functionality into their own components:
-  `FavoritePostList`
- `PostsTagChips`
- `PostsToolbar`

And hooks:
- `useDebouncedSearch()`
- `useFeedMap()`
- `useOpenPostFromRoute()`