### PR TITLE
perf: batch post inserts and limit polling concurrency

### DIFF
--- a/database/src/models/post.rs
+++ b/database/src/models/post.rs
@@ -52,6 +52,36 @@ impl Post {
         Ok(())
     }
 
+    /// Inserts many posts in a single statement.
+    ///
+    /// Rows that conflict on `(feed_id, url)` are silently skipped via
+    /// `ON CONFLICT DO NOTHING`, so re-fetching a feed never errors on posts
+    /// that already exist and never creates duplicates. The returned count is
+    /// the number of rows actually inserted (conflicts excluded).
+    ///
+    /// Because all rows share one statement, error granularity differs from
+    /// inserting row-by-row: a genuine row-level failure (a constraint the
+    /// database cannot skip, e.g. a NOT NULL / CHECK / foreign-key violation)
+    /// or a connection error aborts the whole batch — none of these posts are
+    /// inserted. Duplicate URLs are *not* such a failure; they are handled by
+    /// the conflict clause above.
+    ///
+    /// An empty `forms` is a no-op and returns `Ok(0)` without touching the
+    /// pool.
+    pub async fn create_many(pool: &DatabasePool, forms: Vec<PostInsertForm>) -> WyrmResult<usize> {
+        if forms.is_empty() {
+            return Ok(0);
+        }
+        let mut conn = pool.get().await?;
+        let inserted = diesel::insert_into(posts::table)
+            .values(&forms)
+            .on_conflict((posts::feed_id, posts::url))
+            .do_nothing()
+            .execute(&mut conn)
+            .await?;
+        Ok(inserted)
+    }
+
     pub async fn update(pool: &DatabasePool, form: PostUpdateForm) -> WyrmResult<Self> {
         let mut conn = pool.get().await?;
         diesel::update(posts::table.find(form.id))
@@ -126,5 +156,80 @@ impl PostInsertForm {
             description: entry.summary.map(|s| s.content).or(media_description),
             content: entry.content.and_then(|c| c.body),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use feed_rs::parser;
+
+    fn atom_entry(entry_body: &str) -> Entry {
+        let xml = format!(
+            concat!(
+                r#"<?xml version="1.0" encoding="utf-8"?>"#,
+                r#"<feed xmlns="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/">"#,
+                "<title>Test Feed</title><id>urn:feed</id><updated>2026-01-01T00:00:00Z</updated>",
+                "<entry>{}</entry>",
+                "</feed>",
+            ),
+            entry_body,
+        );
+        parser::parse(xml.as_bytes())
+            .expect("fixture should parse")
+            .entries
+            .into_iter()
+            .next()
+            .expect("fixture should contain an entry")
+    }
+
+    #[test]
+    fn maps_entry_fields() {
+        let entry = atom_entry(concat!(
+            "<id>urn:1</id><title>Hello World</title>",
+            r#"<link href="https://example.com/post/1"/>"#,
+            "<published>2026-01-02T03:04:05Z</published>",
+            "<author><name>Jane Doe</name><email>jane@example.com</email></author>",
+            "<summary>A short summary.</summary>",
+            "<content>Full body.</content>",
+        ));
+
+        let form = PostInsertForm::from_entry(entry, 42);
+
+        assert_eq!(form.feed_id, 42);
+        assert_eq!(form.title.as_deref(), Some("Hello World"));
+        assert_eq!(form.url.as_deref(), Some("https://example.com/post/1"));
+        assert_eq!(form.authors.as_deref(), Some("Jane Doe (jane@example.com)"));
+        assert_eq!(form.description.as_deref(), Some("A short summary."));
+        assert_eq!(form.content.as_deref(), Some("Full body."));
+        assert_eq!(
+            form.published_at,
+            Some("2026-01-02T03:04:05Z".parse::<DateTime<Utc>>().unwrap()),
+        );
+    }
+
+    #[test]
+    fn media_feed_entry_uses_media_description() {
+        let entry = atom_entry(concat!(
+            "<id>urn:video:1</id>",
+            "<title>Test Video</title>",
+            r#"<link rel="alternate" href="https://example.com/video/1"/>"#,
+            "<author><name>Test Author</name><uri>https://example.com/author</uri></author>",
+            "<published>2026-01-02T03:04:05Z</published>",
+            "<media:group>",
+            "<media:title>Test Video</media:title>",
+            r#"<media:content url="https://example.com/video/1.mp4" type="video/mp4"/>"#,
+            r#"<media:thumbnail url="https://example.com/video/1.jpg"/>"#,
+            "<media:description>Test description.</media:description>",
+            "</media:group>",
+        ));
+
+        let form = PostInsertForm::from_entry(entry, 7);
+
+        assert_eq!(form.title.as_deref(), Some("Test Video"));
+        assert_eq!(form.url.as_deref(), Some("https://example.com/video/1"));
+        assert_eq!(form.authors.as_deref(), Some("Test Author"));
+        assert_eq!(form.description.as_deref(), Some("Test description."));
+        assert_eq!(form.content, None);
     }
 }

--- a/rss/src/worker.rs
+++ b/rss/src/worker.rs
@@ -10,7 +10,7 @@ use database::{
 };
 use futures::future::join_all;
 use std::sync::{Arc, RwLock};
-use tokio::sync::mpsc::Receiver;
+use tokio::sync::{Semaphore, mpsc::Receiver};
 use tracing::{error, info};
 use wyrm_utils::result::WyrmResult;
 
@@ -85,12 +85,19 @@ impl FeedWorker {
 
         info!("Processing {} due feeds", due_feeds.len());
 
+        // Each in-flight feed holds ~1 pool connection. Reserve headroom so polling
+        // can never starve the API handlers of the shared pool.
+        let permits = (self.db_pool.status().max_size / 2).max(1);
+        let semaphore = Arc::new(Semaphore::new(permits));
+
         let tasks: Vec<_> = due_feeds
             .into_iter()
             .map(|feed| {
                 let http = self.http.clone();
                 let pool = self.db_pool.clone();
+                let semaphore = semaphore.clone();
                 tokio::spawn(async move {
+                    let _permit = semaphore.acquire().await.unwrap();
                     if let Err(e) = process_feed(&http, &pool, &feed).await {
                         error!("Failed to process feed {}: {e}", feed.url);
                     }
@@ -102,8 +109,6 @@ impl FeedWorker {
 
         Ok(())
     }
-
-    // async fn fetch_feed(&self, feed: Feed) -> WyrmResult<()> { ... }
 }
 
 /// Fetch -> Parse -> Store -> Update
@@ -114,23 +119,22 @@ async fn process_feed(http: &HttpClient, pool: &DatabasePool, feed: &Feed) -> Wy
 
     let parsed = feed_rs::parser::parse(&bytes[..])?;
 
-    for entry in parsed.entries {
-        let url = entry.links.first().map(|l| l.href.as_str()).unwrap_or("");
+    let forms: Vec<PostInsertForm> = parsed
+        .entries
+        .into_iter()
+        .filter(|entry| {
+            let url = entry.links.first().map(|l| l.href.as_str()).unwrap_or("");
+            !feed
+                .url_filter
+                .iter()
+                .filter_map(|f| f.as_deref())
+                .any(|f| url.contains(f))
+        })
+        .map(|entry| PostInsertForm::from_entry(entry, feed.id))
+        .collect();
 
-        let filtered = feed
-            .url_filter
-            .iter()
-            .filter_map(|f| f.as_deref())
-            .any(|f| url.contains(f));
-
-        if filtered {
-            continue;
-        }
-
-        if let Err(e) = Post::create(pool, PostInsertForm::from_entry(entry, feed.id)).await {
-            error!("Failed to insert post: {e}");
-        }
-    }
+    let inserted = Post::create_many(pool, forms).await?;
+    info!("Inserted {inserted} new posts for feed {}", feed.title);
 
     Feed::update(
         pool,


### PR DESCRIPTION
Replace per-entry Post::create with a single create_many insert.

Limit concurrent feed processing with a semaphore sized to half the pool so polling can't starve API handlers.

Add unit tests for PostInsertForm::from_entry.