### PR TITLE
fix: improve startup config error handling

### DIFF
--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -59,12 +59,13 @@ pub(crate) async fn setup_test_db() -> DatabasePool {
         std::env::set_current_dir(concat!(env!("CARGO_MANIFEST_DIR"), "/.."))
             .expect("should cd to workspace root");
 
-        let conf = WyrmStartupConfig::load();
+        let conf = WyrmStartupConfig::load().expect("should load test config");
         let mut conn = establish_sync_connection(&conf).expect("should connect for migrations");
         run_migrations(&mut conn).expect("should run migrations");
     });
 
-    create_pool(&WyrmStartupConfig::load())
+    let conf = WyrmStartupConfig::load().expect("should load test config");
+    create_pool(&conf)
         .await
         .expect("should build pool against the test database")
 }

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -16,7 +16,7 @@ use wyrm_utils::{
 
 pub async fn start_server() -> WyrmResult<()> {
     info!("Loading settings");
-    let startup_conf = WyrmStartupConfig::load();
+    let startup_conf = WyrmStartupConfig::load()?;
 
     info!("Establishing database connection for migrations");
     let mut db_sync_conn = database::establish_sync_connection(&startup_conf)?;

--- a/utils/src/config.rs
+++ b/utils/src/config.rs
@@ -1,9 +1,8 @@
+use crate::result::WyrmResult;
 use config::{Config, Environment, File};
 use serde::Deserialize;
 use smart_default::SmartDefault;
 use std::net::{IpAddr, Ipv4Addr};
-
-use crate::result::WyrmResult;
 
 #[derive(Debug, Clone, Deserialize, SmartDefault)]
 #[serde(default)]

--- a/utils/src/config.rs
+++ b/utils/src/config.rs
@@ -3,6 +3,8 @@ use serde::Deserialize;
 use smart_default::SmartDefault;
 use std::net::{IpAddr, Ipv4Addr};
 
+use crate::result::WyrmResult;
+
 #[derive(Debug, Clone, Deserialize, SmartDefault)]
 #[serde(default)]
 /// Built from wyrm.toml or env vars
@@ -24,13 +26,12 @@ pub struct WyrmStartupConfig {
 }
 
 impl WyrmStartupConfig {
-    pub fn load() -> Self {
+    pub fn load() -> WyrmResult<Self> {
         Config::builder()
             .add_source(File::with_name("config/wyrm.toml").required(false))
             .add_source(Environment::with_prefix("WYRM"))
-            .build()
-            .unwrap()
+            .build()?
             .try_deserialize()
-            .unwrap()
+            .map_err(Into::into)
     }
 }

--- a/utils/src/error.rs
+++ b/utils/src/error.rs
@@ -1,5 +1,6 @@
 use actix_web::{
-    HttpResponse, error,
+    HttpResponse,
+    error,
     http::{StatusCode, header::ContentType},
 };
 use diesel::result::DatabaseErrorKind;

--- a/utils/src/error.rs
+++ b/utils/src/error.rs
@@ -1,6 +1,5 @@
 use actix_web::{
-    HttpResponse,
-    error,
+    HttpResponse, error,
     http::{StatusCode, header::ContentType},
 };
 use diesel::result::DatabaseErrorKind;
@@ -59,6 +58,8 @@ pub enum WyrmError {
     WorkerError(String),
     #[error("lock poisoned: {0}")]
     LockPoisoned(String),
+    #[error("invalid config: {0}")]
+    StartupConfigError(#[from] config::ConfigError),
 }
 
 impl From<reqwest::Error> for WyrmError {


### PR DESCRIPTION
Replace `unwrap()` which would've caused panics on bad configuration with a better error handling, mapped to a newly created `StartupConfigError`.