### PR TITLE
feat: make unread only the default view

### DIFF
--- a/api/api/src/posts.rs
+++ b/api/api/src/posts.rs
@@ -17,6 +17,7 @@ use wyrm_utils::result::WyrmResult;
 pub struct ListPosts {
     pub page: Option<PaginationCursor>,
     pub tag: Option<String>,
+    pub unread_only: Option<bool>,
     pub search: Option<String>,
     #[serde(default, deserialize_with = "api_utils::posts::de_comma_sep_feed_ids")]
     pub exclude: Option<Vec<FeedId>>,
@@ -50,6 +51,7 @@ pub async fn list(
     let page = PostQuery {
         cursor: query.page,
         tag: query.tag,
+        unread_only: query.unread_only,
         search: query.search,
         exclude: query.exclude,
         ..Default::default()
@@ -70,6 +72,7 @@ pub async fn list_by_feed(
         feed_id: Some(path.into_inner()),
         cursor: query.page,
         search: query.search,
+        unread_only: query.unread_only,
         ..Default::default()
     }
     .list(&ctx.db_pool, page_size)

--- a/database/src/views/post.rs
+++ b/database/src/views/post.rs
@@ -14,6 +14,7 @@ pub struct PostQuery {
     pub feed_id: Option<i32>,
     pub tag: Option<String>,
     pub fav_only: bool,
+    pub unread_only: Option<bool>,
     pub search: Option<String>,
     pub exclude: Option<Vec<FeedId>>,
     pub cursor: Option<PaginationCursor>,
@@ -59,6 +60,10 @@ impl PostQuery {
 
         if self.fav_only {
             query = query.filter(posts::is_favorite.eq(true));
+        }
+
+        if self.unread_only == Some(true) {
+            query = query.filter(posts::is_read.eq(false));
         }
 
         if let Some((timestamp, post_id)) = cursor {

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1068,6 +1068,11 @@
     opacity: 0.5;
     cursor: default;
   }
+
+  &[aria-pressed="true"] {
+    color: var(--accent);
+    background: var(--accent-bg);
+  }
 }
 
 @keyframes spin {

--- a/web/src/cache/posts.ts
+++ b/web/src/cache/posts.ts
@@ -46,11 +46,12 @@ export const postKeys = {
   all: ["posts"] as const,
 
   listPrefix: ["posts", "list"] as const,
-  listed: (tag?: string, search?: string, exclude?: FeedId[]) =>
-    [...postKeys.listPrefix, { tag, search, exclude }] as const,
+  listed: (tag?: string, search?: string, exclude?: FeedId[], unreadOnly?: boolean) =>
+    [...postKeys.listPrefix, { tag, search, exclude, unreadOnly }] as const,
 
   feedPrefix: ["posts", "feed"] as const,
-  byFeed: (feedId: number) => [...postKeys.feedPrefix, feedId] as const,
+  byFeed: (feedId: number, search?: string, unreadOnly?: boolean) =>
+    [...postKeys.feedPrefix, feedId, { search, unreadOnly }] as const,
 
   favoritesPrefix: ["posts", "favorites"] as const,
   favorites: (search?: string) => [...postKeys.favoritesPrefix, { search }] as const,

--- a/web/src/components/PostList.tsx
+++ b/web/src/components/PostList.tsx
@@ -1,7 +1,8 @@
 import { useMemo, useState } from "react";
 import { useOutletContext, useParams } from "react-router-dom";
-import { TbRefresh } from "react-icons/tb";
+import { TbEye, TbEyeOff, TbRefresh } from "react-icons/tb";
 import { usePosts } from "../hooks/usePosts";
+import { useUnreadOnly } from "../hooks/useUnreadOnly";
 import { useFeeds, usePollFeeds, useFeedTags } from "../hooks/useFeeds";
 import { useDebouncedSearch } from "../hooks/useDebouncedSearch";
 import { useOpenPostFromRoute } from "../hooks/useOpenPostFromRoute";
@@ -27,6 +28,8 @@ export function PostList() {
   const pollFeeds = usePollFeeds();
 
   const { search, setSearch, debouncedSearch } = useDebouncedSearch();
+
+  const { unreadOnly, setUnreadOnly } = useUnreadOnly();
 
   const [activeTag, setActiveTag] = useState<string | undefined>(undefined);
 
@@ -57,12 +60,15 @@ export function PostList() {
     fetchNextPage,
     isFetchingNextPage,
     isRefetching }
-    = usePosts({
-      feedId: feedIdNum,
-      tag: showTagChips ? activeTag : undefined,
-      search: debouncedSearch || undefined,
-      exclude
-    });
+    = usePosts(
+      {
+        tag: showTagChips ? activeTag : undefined,
+        search: debouncedSearch || undefined,
+        exclude,
+        unread_only: unreadOnly || undefined,
+      },
+      feedIdNum,
+    );
 
   useOpenPostFromRoute(postId, onOpenPost);
 
@@ -74,6 +80,14 @@ export function PostList() {
   return (
     <div className="pane pane-posts">
       <PostsToolbar value={search} onChange={setSearch}>
+        <button
+          className="posts-refresh-btn"
+          aria-pressed={!unreadOnly}
+          onClick={() => setUnreadOnly(!unreadOnly)}
+          title={unreadOnly ? "Unread only — click to show all posts" : "All posts — click to show unread only"}
+        >
+          {unreadOnly ? <TbEyeOff /> : <TbEye />}
+        </button>
         <button
           className="posts-refresh-btn"
           onClick={() => pollFeeds.mutate()}
@@ -96,7 +110,7 @@ export function PostList() {
         hasNextPage={hasNextPage}
         fetchNextPage={fetchNextPage}
         isFetchingNextPage={isFetchingNextPage}
-        emptyMessage="No posts"
+        emptyMessage={unreadOnly && !debouncedSearch && !activeTag ? "All caught up" : "No posts"}
         renderItem={(post) => (
           <PostItem
             post={post}

--- a/web/src/hooks/usePosts.ts
+++ b/web/src/hooks/usePosts.ts
@@ -9,10 +9,9 @@ import { getArchivedPost, getPost, listArchivedPosts, listFavoritePosts, listPos
 import type { PagedResponse } from "../types/PagedResponse";
 import type { FeedId } from "../types/FeedId";
 import type { PostId } from "../types/PostId";
+import type { ListPosts } from "../types/ListPosts";
 import type { Tag } from "../components/PostsTagChips";
 import { postKeys } from "../cache/posts";
-
-type PostsQuery = { feedId?: FeedId; tag?: string; search?: string; exclude?: FeedId[] };
 
 type ArchivedQuery = { search?: string; tag?: string };
 
@@ -38,11 +37,16 @@ export function usePost(id?: PostId) {
   });
 }
 
-export function usePosts({ feedId, tag, search, exclude }: PostsQuery = {}) {
+// `params.page` is ignored: the infinite query owns the cursor and sets it per page.
+// `feedId` routes to the per-feed endpoint; it moves into ListPosts later.
+export function usePosts(params: ListPosts = {}, feedId?: FeedId) {
+  const { tag, search, exclude, unread_only } = params;
   return useInfiniteQuery(
     feedId
-      ? infinitePostsQuery(postKeys.byFeed(feedId), (page) => listPostsByFeed(feedId, { page, search }))
-      : infinitePostsQuery(postKeys.listed(tag, search, exclude), (page) => listPosts({ page, tag, search, exclude })),
+      ? infinitePostsQuery(postKeys.byFeed(feedId, search, unread_only), (page) =>
+          listPostsByFeed(feedId, { ...params, page }))
+      : infinitePostsQuery(postKeys.listed(tag, search, exclude, unread_only), (page) =>
+          listPosts({ ...params, page })),
   );
 }
 

--- a/web/src/hooks/useUnreadOnly.ts
+++ b/web/src/hooks/useUnreadOnly.ts
@@ -1,0 +1,20 @@
+import { useState } from "react";
+
+const STORAGE_KEY = "wyrm:unread-only";
+
+/**
+ * Whether post lists show only unread posts (the default) or everything.
+ * Persisted in localStorage so the choice survives refreshes and navigation.
+ */
+export function useUnreadOnly() {
+  const [unreadOnly, setUnreadOnlyState] = useState(
+    () => localStorage.getItem(STORAGE_KEY) !== "false",
+  );
+
+  const setUnreadOnly = (value: boolean) => {
+    localStorage.setItem(STORAGE_KEY, String(value));
+    setUnreadOnlyState(value);
+  };
+
+  return { unreadOnly, setUnreadOnly };
+}

--- a/web/src/types/ListPosts.ts
+++ b/web/src/types/ListPosts.ts
@@ -2,4 +2,4 @@
 import type { FeedId } from "./FeedId";
 import type { PaginationCursor } from "./PaginationCursor";
 
-export type ListPosts = { page?: PaginationCursor, tag?: string, search?: string, exclude?: Array<FeedId>, };
+export type ListPosts = { page?: PaginationCursor, tag?: string, unread_only?: boolean, search?: string, exclude?: Array<FeedId>, };

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -25,18 +25,23 @@ export const ENDPOINTS = {
     poll: () => `${BASE}/feeds/poll`,
   },
   posts: {
-    list: ({ page, tag, search, exclude }: ListPosts) =>
+    list: ({ page, tag, unread_only, search, exclude }: ListPosts) =>
       buildUrl(`${BASE}/posts`, {
         page,
         tag,
+        unread_only: unread_only ? "true" : undefined,
         search,
         exclude: exclude?.length ? exclude.join(",") : undefined,
       }),
 
     get: (id: PostId) => `${BASE}/posts/${id}`,
 
-    listByFeed: (id: FeedId, { page, search }: ListPosts) =>
-      buildUrl(`${BASE}/feeds/${id}/posts`, { page, search }),
+    listByFeed: (id: FeedId, { page, unread_only, search }: ListPosts) =>
+      buildUrl(`${BASE}/feeds/${id}/posts`, {
+        page,
+        unread_only: unread_only ? "true" : undefined,
+        search,
+      }),
 
     listFavorites: ({ page, search }: ListPosts) =>
       buildUrl(`${BASE}/posts/favorites`, { page, search }),


### PR DESCRIPTION
The list_posts api has been changed to support a unread_only query string which makes the api return unread only posts. This is used by the newly added toggle in the frontend where the user is able to switch between "unread only" and "all" view.

Home and feed views default to unread-only: read posts stay dimmed in place during a session and drop out on the next refetch (navigation/refresh). In show-all mode nothing ever disappears. Archive and favorites are unchanged.

- eye toggle in the posts toolbar, persisted in localStorage
- usePosts now takes ListPosts directly (local PostsQuery type removed), feedId as a separate arg until it moves into ListPosts
- per-feed query cache key now includes search + unread flag (previously all per-feed searches shared one cache entry)
- "All caught up" empty state when unread-only with no search/tag filter