### PR TITLE
refactor: consolidate post list endpoints into GET /posts

### DIFF
--- a/api/api/src/posts.rs
+++ b/api/api/src/posts.rs
@@ -16,7 +16,9 @@ use wyrm_utils::result::WyrmResult;
 #[ts(optional_fields, export)]
 pub struct ListPosts {
     pub page: Option<PaginationCursor>,
+    pub feed_id: Option<FeedId>,
     pub tag: Option<String>,
+    pub fav_only: Option<bool>,
     pub unread_only: Option<bool>,
     pub search: Option<String>,
     #[serde(default, deserialize_with = "api_utils::posts::de_comma_sep_feed_ids")]
@@ -50,47 +52,12 @@ pub async fn list(
     let page_size = ctx.runtime_settings.read()?.page_size;
     let page = PostQuery {
         cursor: query.page,
+        feed_id: query.feed_id,
         tag: query.tag,
+        fav_only: query.fav_only,
         unread_only: query.unread_only,
         search: query.search,
         exclude: query.exclude,
-        ..Default::default()
-    }
-    .list(&ctx.db_pool, page_size)
-    .await?;
-    Ok(Json(page))
-}
-
-pub async fn list_by_feed(
-    path: Path<i32>,
-    query: Query<ListPosts>,
-    ctx: Data<WyrmContext>,
-) -> WyrmResult<Json<PagedResponse<Vec<Post>>>> {
-    let query = query.into_inner();
-    let page_size = ctx.runtime_settings.read()?.page_size;
-    let page = PostQuery {
-        feed_id: Some(path.into_inner()),
-        cursor: query.page,
-        search: query.search,
-        unread_only: query.unread_only,
-        ..Default::default()
-    }
-    .list(&ctx.db_pool, page_size)
-    .await?;
-    Ok(Json(page))
-}
-
-pub async fn list_favorites(
-    query: Query<ListPosts>,
-    ctx: Data<WyrmContext>,
-) -> WyrmResult<Json<PagedResponse<Vec<Post>>>> {
-    let query = query.into_inner();
-    let page_size = ctx.runtime_settings.read()?.page_size;
-    let page = PostQuery {
-        fav_only: true,
-        cursor: query.page,
-        search: query.search,
-        ..Default::default()
     }
     .list(&ctx.db_pool, page_size)
     .await?;

--- a/api/routes/src/posts.rs
+++ b/api/routes/src/posts.rs
@@ -5,19 +5,17 @@ use api_api::{
 };
 
 pub fn config(cfg: &mut web::ServiceConfig) {
-    cfg.service(web::scope("/feeds/{feed_id}/posts").route("", web::get().to(posts::list_by_feed)))
-        .service(
-            web::scope("/posts")
-                .route("", web::get().to(posts::list))
-                .route("/favorites", web::get().to(posts::list_favorites))
-                .service(
-                    web::scope("/archive")
-                        .route("", web::get().to(archive::list))
-                        .route("/{post_id}", web::get().to(archive::get))
-                        .route("/{post_id}", web::delete().to(posts::unarchive))
-                        .route("/{post_id}", web::post().to(posts::archive)),
-                )
-                .route("/{post_id}", web::get().to(posts::get))
-                .route("/{post_id}", web::patch().to(api_crud::posts::update)),
-        );
+    cfg.service(
+        web::scope("/posts")
+            .route("", web::get().to(posts::list))
+            .service(
+                web::scope("/archive")
+                    .route("", web::get().to(archive::list))
+                    .route("/{post_id}", web::get().to(archive::get))
+                    .route("/{post_id}", web::delete().to(posts::unarchive))
+                    .route("/{post_id}", web::post().to(posts::archive)),
+            )
+            .route("/{post_id}", web::get().to(posts::get))
+            .route("/{post_id}", web::patch().to(api_crud::posts::update)),
+    );
 }

--- a/database/src/views/post.rs
+++ b/database/src/views/post.rs
@@ -11,9 +11,9 @@ use wyrm_utils::{error::WyrmError, result::WyrmResult};
 
 #[derive(Default)]
 pub struct PostQuery {
-    pub feed_id: Option<i32>,
+    pub feed_id: Option<FeedId>,
     pub tag: Option<String>,
-    pub fav_only: bool,
+    pub fav_only: Option<bool>,
     pub unread_only: Option<bool>,
     pub search: Option<String>,
     pub exclude: Option<Vec<FeedId>>,
@@ -58,7 +58,7 @@ impl PostQuery {
             query = query.filter(posts::feed_id.ne_all(exclude))
         }
 
-        if self.fav_only {
+        if self.fav_only == Some(true) {
             query = query.filter(posts::is_favorite.eq(true));
         }
 

--- a/web/src/api/posts.ts
+++ b/web/src/api/posts.ts
@@ -1,5 +1,4 @@
 import type { Post } from "../types/Post";
-import type { FeedId } from "../types/FeedId";
 import type { PostId } from "../types/PostId";
 import type { PagedResponse } from "../types/PagedResponse";
 import type { UpdatePost } from "../types/UpdatePost";
@@ -15,12 +14,6 @@ export const listPosts = (params: ListPosts): Promise<PagedResponse<Array<Post>>
 
 export const getPost = (id: PostId): Promise<Post> =>
   fetchWithAuth(ENDPOINTS.posts.get(id)).then<Post>(json);
-
-export const listPostsByFeed = (id: FeedId, params: ListPosts): Promise<PagedResponse<Array<Post>>> =>
-  fetchWithAuth(ENDPOINTS.posts.listByFeed(id, params)).then<PagedResponse<Array<Post>>>(json);
-
-export const listFavoritePosts = (params: ListPosts): Promise<PagedResponse<Array<Post>>> =>
-  fetchWithAuth(ENDPOINTS.posts.listFavorites(params)).then<PagedResponse<Array<Post>>>(json);
 
 export const listArchivedPosts = (params: ListPostArchive): Promise<PagedResponse<Array<PostArchive>>> =>
   fetchWithAuth(ENDPOINTS.posts.listArchived(params)).then<PagedResponse<Array<PostArchive>>>(json);

--- a/web/src/components/PostList.tsx
+++ b/web/src/components/PostList.tsx
@@ -60,15 +60,13 @@ export function PostList() {
     fetchNextPage,
     isFetchingNextPage,
     isRefetching }
-    = usePosts(
-      {
-        tag: showTagChips ? activeTag : undefined,
-        search: debouncedSearch || undefined,
-        exclude,
-        unread_only: unreadOnly || undefined,
-      },
-      feedIdNum,
-    );
+    = usePosts({
+      feed_id: feedIdNum,
+      tag: showTagChips ? activeTag : undefined,
+      search: debouncedSearch || undefined,
+      exclude,
+      unread_only: unreadOnly || undefined,
+    });
 
   useOpenPostFromRoute(postId, onOpenPost);
 

--- a/web/src/hooks/usePosts.ts
+++ b/web/src/hooks/usePosts.ts
@@ -5,9 +5,8 @@ import {
   useQuery,
   type QueryKey,
 } from "@tanstack/react-query";
-import { getArchivedPost, getPost, listArchivedPosts, listFavoritePosts, listPosts, listPostsByFeed } from "../api/posts";
+import { getArchivedPost, getPost, listArchivedPosts, listPosts } from "../api/posts";
 import type { PagedResponse } from "../types/PagedResponse";
-import type { FeedId } from "../types/FeedId";
 import type { PostId } from "../types/PostId";
 import type { ListPosts } from "../types/ListPosts";
 import type { Tag } from "../components/PostsTagChips";
@@ -38,21 +37,22 @@ export function usePost(id?: PostId) {
 }
 
 // `params.page` is ignored: the infinite query owns the cursor and sets it per page.
-// `feedId` routes to the per-feed endpoint; it moves into ListPosts later.
-export function usePosts(params: ListPosts = {}, feedId?: FeedId) {
-  const { tag, search, exclude, unread_only } = params;
+// `feed_id` scopes the list to one feed and keeps its own cache namespace.
+export function usePosts(params: ListPosts = {}) {
+  const { feed_id, tag, search, exclude, unread_only } = params;
   return useInfiniteQuery(
-    feedId
-      ? infinitePostsQuery(postKeys.byFeed(feedId, search, unread_only), (page) =>
-          listPostsByFeed(feedId, { ...params, page }))
-      : infinitePostsQuery(postKeys.listed(tag, search, exclude, unread_only), (page) =>
-          listPosts({ ...params, page })),
+    infinitePostsQuery(
+      feed_id
+        ? postKeys.byFeed(feed_id, search, unread_only)
+        : postKeys.listed(tag, search, exclude, unread_only),
+      (page) => listPosts({ ...params, page }),
+    ),
   );
 }
 
 export function useFavoritePosts(search?: string) {
   return useInfiniteQuery(
-    infinitePostsQuery(postKeys.favorites(search), (page) => listFavoritePosts({ page, search })),
+    infinitePostsQuery(postKeys.favorites(search), (page) => listPosts({ fav_only: true, page, search })),
   );
 }
 

--- a/web/src/types/ListPosts.ts
+++ b/web/src/types/ListPosts.ts
@@ -2,4 +2,4 @@
 import type { FeedId } from "./FeedId";
 import type { PaginationCursor } from "./PaginationCursor";
 
-export type ListPosts = { page?: PaginationCursor, tag?: string, unread_only?: boolean, search?: string, exclude?: Array<FeedId>, };
+export type ListPosts = { page?: PaginationCursor, feed_id?: FeedId, tag?: string, fav_only?: boolean, unread_only?: boolean, search?: string, exclude?: Array<FeedId>, };

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -25,26 +25,18 @@ export const ENDPOINTS = {
     poll: () => `${BASE}/feeds/poll`,
   },
   posts: {
-    list: ({ page, tag, unread_only, search, exclude }: ListPosts) =>
+    list: ({ page, feed_id, tag, fav_only, unread_only, search, exclude }: ListPosts) =>
       buildUrl(`${BASE}/posts`, {
         page,
+        feed_id: feed_id !== undefined ? String(feed_id) : undefined,
         tag,
+        fav_only: fav_only ? "true" : undefined,
         unread_only: unread_only ? "true" : undefined,
         search,
         exclude: exclude?.length ? exclude.join(",") : undefined,
       }),
 
     get: (id: PostId) => `${BASE}/posts/${id}`,
-
-    listByFeed: (id: FeedId, { page, unread_only, search }: ListPosts) =>
-      buildUrl(`${BASE}/feeds/${id}/posts`, {
-        page,
-        unread_only: unread_only ? "true" : undefined,
-        search,
-      }),
-
-    listFavorites: ({ page, search }: ListPosts) =>
-      buildUrl(`${BASE}/posts/favorites`, { page, search }),
 
     listArchived: ({ page, tag, search }: ListPostArchive) =>
       buildUrl(`${BASE}/posts/archive`, { page, tag, search }),


### PR DESCRIPTION
Replace GET `/feeds/{feed_id}/posts` and GET `/posts/favorites` with `feed_id` and `fav_only` query params on `GET /posts`. PostQuery now takes FeedId and Option<bool> for these fields, and the handler maps the query struct through without per-endpoint defaults.

On the frontend, listPostsByFeed/listFavoritePosts are gone; usePosts takes feed_id inside ListPosts instead of a separate argument. The dedicated byFeed and favorites cache keys are kept so targeted invalidation still works