### PR TITLE
refactor: make unread-only the GET /posts API default

### DIFF
--- a/api/api/src/posts.rs
+++ b/api/api/src/posts.rs
@@ -55,7 +55,7 @@ pub async fn list(
         feed_id: query.feed_id,
         tag: query.tag,
         fav_only: query.fav_only,
-        unread_only: query.unread_only,
+        unread_only: query.unread_only.or(Some(true)),
         search: query.search,
         exclude: query.exclude,
     }

--- a/web/src/components/PostList.tsx
+++ b/web/src/components/PostList.tsx
@@ -65,7 +65,8 @@ export function PostList() {
       tag: showTagChips ? activeTag : undefined,
       search: debouncedSearch || undefined,
       exclude,
-      unread_only: unreadOnly || undefined,
+      // unread-only is the API default; only "all" mode needs the param
+      unread_only: unreadOnly ? undefined : false,
     });
 
   useOpenPostFromRoute(postId, onOpenPost);

--- a/web/src/hooks/usePosts.ts
+++ b/web/src/hooks/usePosts.ts
@@ -52,7 +52,9 @@ export function usePosts(params: ListPosts = {}) {
 
 export function useFavoritePosts(search?: string) {
   return useInfiniteQuery(
-    infinitePostsQuery(postKeys.favorites(search), (page) => listPosts({ fav_only: true, page, search })),
+    infinitePostsQuery(postKeys.favorites(search), (page) =>
+      // explicit false: favorites are usually read, the unread-only API default would hide them
+      listPosts({ fav_only: true, unread_only: false, page, search })),
   );
 }
 

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -31,7 +31,7 @@ export const ENDPOINTS = {
         feed_id: feed_id !== undefined ? String(feed_id) : undefined,
         tag,
         fav_only: fav_only ? "true" : undefined,
-        unread_only: unread_only ? "true" : undefined,
+        unread_only: unread_only !== undefined ? String(unread_only) : undefined,
         search,
         exclude: exclude?.length ? exclude.join(",") : undefined,
       }),


### PR DESCRIPTION
Apply `unread_only.or(Some(true))` at the list_posts handler, so a `GET /posts` without unread_only query string returns unread posts and clients opt out with `unread_only=false`. PostQuery/DB-layer semantics are unchanged.

Frontend now sends the param only in "all" mode, and the favorites view sends an explicit false since favorites are usually read and the default would hide them.