### PR TITLE
refactor: sort post lists by id instead of published_at

### DIFF
--- a/database/src/utils/pagination.rs
+++ b/database/src/utils/pagination.rs
@@ -1,4 +1,3 @@
-use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, ts_rs::TS)]
@@ -15,14 +14,11 @@ pub struct PagedResponse<T: ts_rs::TS> {
 }
 
 impl PaginationCursor {
-    pub fn encode(published_at: DateTime<Utc>, id: i32) -> Self {
-        Self(format!("{}:{}", published_at.timestamp_millis(), id))
+    pub fn encode(id: i32) -> Self {
+        Self(id.to_string())
     }
 
-    pub fn decode(&self) -> Option<(DateTime<Utc>, i32)> {
-        let (ms_str, id_str) = self.0.split_once(':')?;
-        let ms: i64 = ms_str.parse().ok()?;
-        let id: i32 = id_str.parse().ok()?;
-        Some((DateTime::from_timestamp_millis(ms)?, id))
+    pub fn decode(&self) -> Option<i32> {
+        self.0.parse().ok()
     }
 }

--- a/database/src/views/archive.rs
+++ b/database/src/views/archive.rs
@@ -44,7 +44,7 @@ impl PostArchiveQuery {
 
         let mut query = post_archive::table
             .select(PostArchive::as_select())
-            .order((post_archive::published_at.desc(), post_archive::id.desc()))
+            .order(post_archive::id.desc())
             .limit(page_size as i64 + 1)
             .into_boxed();
 
@@ -60,22 +60,14 @@ impl PostArchiveQuery {
             );
         }
 
-        if let Some((timestamp, post_id)) = cursor {
-            query = query.filter(
-                post_archive::published_at
-                    .lt(timestamp)
-                    .or(post_archive::published_at
-                        .eq(timestamp)
-                        .and(post_archive::id.lt(post_id))),
-            );
+        if let Some(post_id) = cursor {
+            query = query.filter(post_archive::id.lt(post_id));
         }
 
         let mut items: Vec<PostArchive> = query.load(&mut conn).await.map_err(WyrmError::from)?;
         let next_page = if items.len() > page_size as usize {
             items.truncate(page_size as usize);
-            items
-                .last()
-                .map(|p| PaginationCursor::encode(p.published_at, p.id.0))
+            items.last().map(|p| PaginationCursor::encode(p.id.0))
         } else {
             None
         };

--- a/database/src/views/post.rs
+++ b/database/src/views/post.rs
@@ -32,7 +32,7 @@ impl PostQuery {
 
         let mut query = posts::table
             .select(Post::as_select())
-            .order((posts::published_at.desc(), posts::id.desc()))
+            .order(posts::id.desc())
             .limit(page_size as i64 + 1)
             .into_boxed();
 
@@ -66,20 +66,14 @@ impl PostQuery {
             query = query.filter(posts::is_read.eq(false));
         }
 
-        if let Some((timestamp, post_id)) = cursor {
-            query = query.filter(
-                posts::published_at
-                    .lt(timestamp)
-                    .or(posts::published_at.eq(timestamp).and(posts::id.lt(post_id))),
-            );
+        if let Some(post_id) = cursor {
+            query = query.filter(posts::id.lt(post_id));
         }
 
         let mut items: Vec<Post> = query.load(&mut conn).await.map_err(WyrmError::from)?;
         let next_page = if items.len() > page_size as usize {
             items.truncate(page_size as usize);
-            items
-                .last()
-                .map(|p| PaginationCursor::encode(p.published_at, p.id.0))
+            items.last().map(|p| PaginationCursor::encode(p.id.0))
         } else {
             None
         };


### PR DESCRIPTION
Order posts and archive by insertion order (serial id) so newly ingested posts always show at the top.
The pagination cursor simplifies from a "timestamp:id" pair to just id, since the sort key is now unique on its own;

Note: archive rows keep their original post id, so the archive is now ordered by original ingestion time rather than publish date.