### PR TITLE
 feat: discover feed URLs from page URLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,6 +677,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "cssparser"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9cdaae01d5ed7882b04d795e7f752f46ff52d2fa3b50a20d28c464510bba98"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a2a99df6e410a8ff4245aa2006499ea662245f967cc7c0a38c83ef8eb44dbf"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ctutils"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -971,6 +994,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
+dependencies = [
+ "dtoa",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -981,6 +1019,12 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "ego-tree"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b04dc5a38e4f151a79d9f2451ae6037fb6eaf5cba34771f44781f80e508498e3"
 
 [[package]]
 name = "either"
@@ -1029,6 +1073,12 @@ name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "feed-rs"
@@ -1195,6 +1245,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1349,6 +1408,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest 0.11.3",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
+dependencies = [
+ "log",
+ "markup5ever",
 ]
 
 [[package]]
@@ -1817,6 +1886,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "markup5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
+dependencies = [
+ "log",
+ "tendril",
+ "web_atoms",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1898,6 +1978,12 @@ dependencies = [
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nu-ansi-term"
@@ -2057,8 +2143,42 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
+ "phf_macros",
  "phf_shared",
  "serde",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2151,6 +2271,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
@@ -2649,6 +2775,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scraper"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd0be4d296f048bfb06dd01bbc80ef789ddd2e55583e8d2e6b804942abfabc2"
+dependencies = [
+ "cssparser",
+ "ego-tree",
+ "getopts",
+ "html5ever",
+ "precomputed-hash",
+ "selectors",
+ "tendril",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2669,6 +2810,25 @@ checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "selectors"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8adfa1c298912827b8a28b223b3b874357397ae706e6190acd9bf28cee99114d"
+dependencies = [
+ "bitflags",
+ "cssparser",
+ "derive_more",
+ "log",
+ "new_debug_unreachable",
+ "phf",
+ "phf_codegen",
+ "precomputed-hash",
+ "rustc-hash",
+ "servo_arc",
+ "smallvec",
 ]
 
 [[package]]
@@ -2798,6 +2958,15 @@ dependencies = [
  "tracing-subscriber",
  "wyrm-rss",
  "wyrm_utils",
+]
+
+[[package]]
+name = "servo_arc"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
+dependencies = [
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -2936,6 +3105,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "string_cache"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3008,6 +3201,15 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "tendril"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fed54709c5b3a53d09bb1c113ea4f5ceafd1e772ddcb0030a82e1d56c087b08"
+dependencies = [
+ "new_debug_unreachable",
 ]
 
 [[package]]
@@ -3449,6 +3651,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3690,6 +3898,18 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web_atoms"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
+dependencies = [
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
 ]
 
 [[package]]
@@ -4005,6 +4225,7 @@ dependencies = [
  "reqwest",
  "reqwest-middleware",
  "reqwest-retry",
+ "scraper",
  "serde",
  "serde_json",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,4 @@ feed-rs = "2.3.1"
 ts-rs = { version = "12.0.1", features = ["chrono-impl", "no-serde-warnings"] }
 serde_with = "3.20.0"
 quick-xml = { version = "0.41.0", features = ["serialize"] }
+scraper = "0.27.0"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@
 ## Features
 
 - Subscribe to RSS and Atom feeds
-- YouTube channel support — subscribe to any channel's RSS feed and watch videos inline without leaving the reader
+- Feed discovery — paste a blog homepage or YouTube channel URL and Wyrm finds the feed for you
+- YouTube channel support — subscribe to any channel and watch videos inline without leaving the reader
 - Browse posts per feed or across all feeds
 - Group feeds into folders — collapsible sidebar sections with unread counts, preserved across OPML import/export
 - Filters per feed — exclude entries matching a pattern, scoped to URL, title or content

--- a/api/crud/src/feeds.rs
+++ b/api/crud/src/feeds.rs
@@ -5,6 +5,7 @@ use database::{
     newtypes::FeedId,
 };
 use serde::Deserialize;
+use wyrm_rss::discover::resolve_feed_url;
 use wyrm_utils::result::WyrmResult;
 
 #[derive(Deserialize, ts_rs::TS)]
@@ -36,11 +37,14 @@ pub async fn create(
     Json(data): Json<CreateFeed>,
     ctx: Data<WyrmContext>,
 ) -> WyrmResult<Json<Feed>> {
+    // A page URL (blog homepage, YouTube channel) resolves to the feed it
+    // advertises; a URL that already serves a feed passes through unchanged.
+    let url = resolve_feed_url(&ctx.http, &data.url).await?;
     let feed = Feed::create(
         &ctx.db_pool,
         FeedInsertForm {
             title: data.title,
-            url: data.url,
+            url,
             ttl: data.ttl,
             folder: data.folder,
             filters: data.filters.map(|v| v.into_iter().map(Some).collect()),
@@ -55,12 +59,24 @@ pub async fn update(
     Json(data): Json<UpdateFeed>,
     ctx: Data<WyrmContext>,
 ) -> WyrmResult<Json<Feed>> {
+    let id = path.into_inner();
+    // Only a *changed* URL triggers discovery. The edit form always sends the
+    // url field, so an unchanged one must pass through without a network
+    // round-trip — otherwise a TTL/title edit would fail while the feed's
+    // site happens to be down.
+    let feed = Feed::get(&ctx.db_pool, id).await?;
+    let url = match data.url {
+        Some(u) if u == feed.url => Some(u),
+        Some(u) => Some(resolve_feed_url(&ctx.http, &u).await?),
+        None => None,
+    };
+
     let feed = Feed::update(
         &ctx.db_pool,
         FeedUpdateForm {
-            id: path.into_inner(),
+            id,
             title: data.title,
-            url: data.url,
+            url,
             ttl: data.ttl,
             folder: data.folder,
             filters: data.filters.map(|v| v.into_iter().map(Some).collect()),

--- a/rss/Cargo.toml
+++ b/rss/Cargo.toml
@@ -19,6 +19,7 @@ chrono = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 quick-xml = { workspace = true }
+scraper = { workspace = true }
 wyrm_utils = { path = "../utils" }
 wyrm_webhook = { path = "../webhook" }
 database = { path = "../database" }

--- a/rss/src/discover.rs
+++ b/rss/src/discover.rs
@@ -1,0 +1,202 @@
+//! Feed URL discovery: turns a user-supplied page URL into a feed URL.
+//!
+//! A submitted URL that already serves RSS/Atom passes through unchanged.
+//! For HTML pages we look for the standard autodiscovery tag
+//! (`<link rel="alternate" type="application/rss+xml" href="…">`), which
+//! covers most blogs as well as YouTube channel pages in all their URL
+//! shapes (`/@handle`, `/channel/…`, `/c/…`, `/user/…`). Two YouTube
+//! extras: `/channel/<id>` URLs are rewritten without a network round-trip,
+//! and pages served without the autodiscovery tag (consent walls, degraded
+//! bot HTML) fall back to scraping the embedded `"channelId"`.
+
+use crate::http::HttpClient;
+use scraper::{Html, Selector};
+use tracing::warn;
+use wyrm_utils::{error::WyrmError, result::WyrmResult};
+
+/// Resolves `url` to the feed URL to store. Fails with a client-facing
+/// error only on positive evidence: the page fetched fine and advertises no
+/// feed. An unreachable host passes the URL through unchanged — down is not
+/// invalid (YouTube/Reddit feeds have dead windows), and the poller retries
+/// forever anyway.
+pub async fn resolve_feed_url(http: &HttpClient, url: &str) -> WyrmResult<String> {
+    if let Some(feed) = youtube_channel_shortcut(url) {
+        return Ok(feed);
+    }
+
+    let bytes = match http.fetch(url).await {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            warn!("feed discovery: could not fetch {url}, storing as-is: {e}");
+            return Ok(url.to_string());
+        }
+    };
+
+    if feed_rs::parser::parse(&bytes[..]).is_ok() {
+        return Ok(url.to_string());
+    }
+
+    let body = String::from_utf8_lossy(&bytes);
+    if let Some(href) = find_alternate_link(&body) {
+        return absolutize(url, &href);
+    }
+    if let Some(id) = find_channel_id(&body) {
+        return Ok(youtube_feed_url(id));
+    }
+
+    Err(WyrmError::FeedDiscovery(format!("no feed found at {url}")))
+}
+
+fn youtube_feed_url(channel_id: &str) -> String {
+    format!("https://www.youtube.com/feeds/videos.xml?channel_id={channel_id}")
+}
+
+/// `youtube.com/channel/<id>` already contains the channel id, so the feed
+/// URL can be built directly. A malformed id falls through to the fetch
+/// path instead of silently creating a feed that would 404 at poll time.
+fn youtube_channel_shortcut(url: &str) -> Option<String> {
+    let parsed = reqwest::Url::parse(url).ok()?;
+    let host = parsed.host_str()?;
+    if !matches!(host, "www.youtube.com" | "youtube.com" | "m.youtube.com") {
+        return None;
+    }
+    let mut segments = parsed.path_segments()?;
+    if segments.next()? != "channel" {
+        return None;
+    }
+    let id = segments.next()?;
+    is_channel_id(id).then(|| youtube_feed_url(id))
+}
+
+/// Channel ids are exactly 24 URL-safe-base64 characters starting with "UC".
+fn is_channel_id(id: &str) -> bool {
+    id.starts_with("UC")
+        && id.len() == 24
+        && id
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
+}
+
+/// Finds the first RSS/Atom autodiscovery `<link>` in an HTML document and
+/// returns its `href`.
+fn find_alternate_link(html: &str) -> Option<String> {
+    let selector = Selector::parse(
+        r#"link[rel~="alternate" i][type="application/rss+xml" i],
+           link[rel~="alternate" i][type="application/atom+xml" i]"#,
+    )
+    .expect("static selector is valid");
+
+    Html::parse_document(html)
+        .select(&selector)
+        .find_map(|link| link.value().attr("href").map(String::from))
+}
+
+/// YouTube pages embed `"channelId":"UC…"` in their initial-data JSON even
+/// when the autodiscovery tag is missing.
+fn find_channel_id(html: &str) -> Option<&str> {
+    const KEY: &str = "\"channelId\":\"";
+    let start = html.find(KEY)? + KEY.len();
+    let rest = &html[start..];
+    let id = &rest[..rest.find('"')?];
+    is_channel_id(id).then_some(id)
+}
+
+/// Resolves a discovered `href` (possibly relative) against the page URL.
+fn absolutize(base: &str, href: &str) -> WyrmResult<String> {
+    reqwest::Url::parse(base)
+        .and_then(|b| b.join(href))
+        .map(String::from)
+        .map_err(|_| WyrmError::FeedDiscovery(format!("invalid feed link discovered at {base}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn channel_url_rewrites_without_fetching() {
+        for url in [
+            "https://www.youtube.com/channel/UCVBlOjOg74sx8Gk8Zjmjyrg",
+            "https://youtube.com/channel/UCVBlOjOg74sx8Gk8Zjmjyrg/videos",
+            "https://m.youtube.com/channel/UCVBlOjOg74sx8Gk8Zjmjyrg",
+        ] {
+            assert_eq!(
+                youtube_channel_shortcut(url).as_deref(),
+                Some(
+                    "https://www.youtube.com/feeds/videos.xml?channel_id=UCVBlOjOg74sx8Gk8Zjmjyrg"
+                )
+            );
+        }
+    }
+
+    #[test]
+    fn non_channel_urls_are_not_shortcut() {
+        assert_eq!(
+            youtube_channel_shortcut("https://www.youtube.com/@handle"),
+            None
+        );
+        assert_eq!(
+            youtube_channel_shortcut("https://example.com/channel/UC123"),
+            None
+        );
+        assert_eq!(youtube_channel_shortcut("not a url"), None);
+        // A malformed id must fall through to the fetch path, not build a
+        // feed URL that would 404 at poll time.
+        assert_eq!(
+            youtube_channel_shortcut("https://www.youtube.com/channel/garbage"),
+            None
+        );
+    }
+
+    #[test]
+    fn finds_alternate_link_regardless_of_attribute_order_or_case() {
+        let youtube_style = r#"<html><head><link rel="alternate" type="application/rss+xml" title="RSS" href="https://www.youtube.com/feeds/videos.xml?channel_id=UCabc"></head></html>"#;
+        assert_eq!(
+            find_alternate_link(youtube_style).as_deref(),
+            Some("https://www.youtube.com/feeds/videos.xml?channel_id=UCabc")
+        );
+
+        let reordered = r#"<LINK HREF='/feed.xml' TYPE='application/ATOM+xml' REL='Alternate'/>"#;
+        assert_eq!(find_alternate_link(reordered).as_deref(), Some("/feed.xml"));
+    }
+
+    #[test]
+    fn ignores_stylesheets_and_decodes_entities() {
+        let html = r#"
+            <link rel="stylesheet" href="/style.css">
+            <link rel="alternate" type="application/rss+xml" href="/feed?a=1&amp;b=2">
+        "#;
+        assert_eq!(find_alternate_link(html).as_deref(), Some("/feed?a=1&b=2"));
+        assert_eq!(find_alternate_link("<p>no links here</p>"), None);
+    }
+
+    #[test]
+    fn channel_id_fallback_validates_shape() {
+        let html = r#"{"channelId":"UCVBlOjOg74sx8Gk8Zjmjyrg","title":"x"}"#;
+        assert_eq!(find_channel_id(html), Some("UCVBlOjOg74sx8Gk8Zjmjyrg"));
+
+        // Wrong prefix, wrong length, or bad characters are rejected.
+        assert_eq!(
+            find_channel_id(r#"{"channelId":"XXVBlOjOg74sx8Gk8Zjmjyrg"}"#),
+            None
+        );
+        assert_eq!(find_channel_id(r#"{"channelId":"UCshort"}"#), None);
+        assert_eq!(
+            find_channel_id(r#"{"channelId":"UCVBlOjOg74sx8Gk8Zjm.yrg"}"#),
+            None
+        );
+    }
+
+    #[test]
+    fn absolutize_resolves_relative_hrefs() {
+        assert_eq!(
+            absolutize("https://example.com/blog/post", "/feed.xml").unwrap(),
+            "https://example.com/feed.xml"
+        );
+        assert_eq!(
+            absolutize("https://example.com/", "https://other.com/rss").unwrap(),
+            "https://other.com/rss"
+        );
+        assert!(absolutize("nonsense", "/feed.xml").is_err());
+    }
+}

--- a/rss/src/http.rs
+++ b/rss/src/http.rs
@@ -1,4 +1,4 @@
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use database::utils::settings::RuntimeSettings;
 use http::Extensions;
 use reqwest::{Request, Response};
@@ -6,7 +6,13 @@ use reqwest_middleware::{ClientBuilder, ClientWithMiddleware, Middleware, Next, 
 use reqwest_retry::{RetryTransientMiddleware, policies::ExponentialBackoff};
 use std::time::Duration;
 use tracing::info;
-use wyrm_utils::result::WyrmResult;
+use wyrm_utils::{error::HttpClientError, result::WyrmResult};
+
+/// Hard cap on fetched bodies: full-content feeds run a few MB; anything
+/// larger is not a feed (or a page advertising one). Applied to bytes after
+/// transparent gzip decompression, so oversized *and* highly-compressed
+/// responses both bail instead of exhausting memory.
+const MAX_RESPONSE_BYTES: usize = 10 * 1024 * 1024;
 
 struct LoggingMiddleware;
 
@@ -80,10 +86,24 @@ impl HttpClient {
     }
 
     pub async fn fetch(&self, url: &str) -> WyrmResult<Bytes> {
-        let response = self.inner.get(url).send().await?;
-        let bytes = response.bytes().await?;
+        let mut response = self.inner.get(url).send().await?;
 
-        Ok(bytes)
+        if response
+            .content_length()
+            .is_some_and(|len| len as usize > MAX_RESPONSE_BYTES)
+        {
+            return Err(HttpClientError::ResponseTooLarge(MAX_RESPONSE_BYTES).into());
+        }
+
+        let mut body = BytesMut::new();
+        while let Some(chunk) = response.chunk().await? {
+            if body.len() + chunk.len() > MAX_RESPONSE_BYTES {
+                return Err(HttpClientError::ResponseTooLarge(MAX_RESPONSE_BYTES).into());
+            }
+            body.extend_from_slice(&chunk);
+        }
+
+        Ok(body.freeze())
     }
 
     pub async fn post_json(&self, url: &str, body: &serde_json::Value) -> WyrmResult<()> {

--- a/rss/src/lib.rs
+++ b/rss/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod discover;
 pub mod filter;
 pub mod http;
 pub mod opml;

--- a/utils/src/error.rs
+++ b/utils/src/error.rs
@@ -11,6 +11,8 @@ pub enum HttpClientError {
     ClientError(#[from] reqwest::Error),
     #[error("middleware error: {0}")]
     MiddlewareError(#[from] reqwest_middleware::Error),
+    #[error("response body exceeds {0} bytes")]
+    ResponseTooLarge(usize),
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -63,6 +65,8 @@ pub enum WyrmError {
     WebhookTemplate(String),
     #[error("folder name cannot be empty")]
     EmptyFolderName,
+    #[error("feed discovery failed: {0}")]
+    FeedDiscovery(String),
     #[error("invalid config: {0}")]
     StartupConfigError(#[from] config::ConfigError),
 }
@@ -120,6 +124,7 @@ impl WyrmError {
             WyrmError::XmlDeserializeError(_) => "invalid request body",
             WyrmError::WebhookTemplate(msg) => msg,
             WyrmError::EmptyFolderName => "folder name cannot be empty",
+            WyrmError::FeedDiscovery(msg) => msg,
             _ => "internal server error",
         }
     }
@@ -149,6 +154,7 @@ impl error::ResponseError for WyrmError {
             WyrmError::XmlDeserializeError(_) => StatusCode::BAD_REQUEST,
             WyrmError::WebhookTemplate(_) => StatusCode::BAD_REQUEST,
             WyrmError::EmptyFolderName => StatusCode::BAD_REQUEST,
+            WyrmError::FeedDiscovery(_) => StatusCode::BAD_REQUEST,
             _ => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }

--- a/web/src/api/folders.ts
+++ b/web/src/api/folders.ts
@@ -1,4 +1,4 @@
-import { ENDPOINTS, json } from "../utils/api";
+import { ApiError, ENDPOINTS, json } from "../utils/api";
 import { fetchWithAuth } from "../utils/auth";
 import type { Folder } from "../types/Folder";
 import type { FolderId } from "../types/FolderId";
@@ -26,12 +26,11 @@ export const deleteFolder = (id: FolderId): Promise<Folder> =>
   fetchWithAuth(ENDPOINTS.folders.delete(id), { method: "DELETE" }).then<Folder>(json);
 
 /**
- * User-facing message for a failed folder rename. `json` above throws
- * `Error("409 Conflict")` for duplicate names; anything else (network, 500)
- * gets the generic message.
+ * User-facing message for a failed folder rename. Duplicate names surface as
+ * a 409; anything else (network, 500) gets the generic message.
  */
 export function renameErrorMessage(error: Error): string {
-  return error.message.startsWith("409")
+  return error instanceof ApiError && error.status === 409
     ? "A folder with that name already exists."
     : "Rename failed.";
 }

--- a/web/src/components/AddFeedForm.tsx
+++ b/web/src/components/AddFeedForm.tsx
@@ -80,6 +80,7 @@ export function AddFeedForm({ onClose }: Props) {
           + Filter
         </button>
       </div>
+      {create.isError && <div className="form-error">{create.error.message}</div>}
       <div className="entity-form-actions">
         <button
           className="btn btn-primary"

--- a/web/src/components/EditFeedForm.tsx
+++ b/web/src/components/EditFeedForm.tsx
@@ -148,6 +148,7 @@ export function EditFeedForm({ feed, onClose }: Props) {
         <span className="feed-webhooks-label">Webhooks</span>
         <FeedWebhooks selected={selectedWebhooks} onToggle={toggleWebhook} />
       </div>
+      {update.isError && <div className="form-error">{update.error.message}</div>}
       <div className="entity-form-actions">
         <button
           className="btn btn-primary"

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -73,12 +73,27 @@ export const ENDPOINTS = {
 } as const;
 
 
+/** API failure carrying the status and the server's curated `error` message. */
+export class ApiError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+  }
+}
+
+async function throwApiError(res: Response): Promise<never> {
+  const body = (await res.json().catch(() => undefined)) as { error?: string } | undefined;
+  throw new ApiError(res.status, body?.error ?? `${res.status} ${res.statusText}`);
+}
+
 export async function json<T>(res: Response): Promise<T> {
   if (res.status === 401) {
     handleUnauthorized();
     throw new Error("Unauthorized");
   }
-  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  if (!res.ok) await throwApiError(res);
   return res.json();
 }
 
@@ -87,5 +102,5 @@ export async function noContent(res: Response): Promise<void> {
     handleUnauthorized();
     throw new Error("Unauthorized");
   }
-  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  if (!res.ok) await throwApiError(res);
 }


### PR DESCRIPTION
Pasting a blog homepage or YouTube channel URL now resolves to the feed it advertises, instead of failing at poll time.

- Added `rss/src/discover.rs`: resolves the feed url at create and update time. For urls that return HTML content, we try to scrape for the feed url via rss autodiscovery, which allows us to find the rss feed for youtube channel urls without requiring the user to convert from channel name to id.
- feed crud `create` always resolve the url and fail if the url is fine but does not provide a valid rss feed, instead of inserting into the database only for polls to fail. Feed crud `update` only resolves the url when the user updates the feed url, as opposed to just updating the ttl for example.
- Added new `FeedDiscovery` error which propagates to the frontend
- Added new `ResponseTooLarge` errors for feed responses that are too large (e.g not rss feed urls)
- we log a warning on unreachable urls and store the URL as-is. 400 only when a page fetched fine and advertises no feed. OPML import stays validation-free for the same reason