### PR TITLE
feat: show feed favicons on post items

### DIFF
--- a/api/api/src/feeds.rs
+++ b/api/api/src/feeds.rs
@@ -1,10 +1,11 @@
 use actix_web::{
     HttpResponse,
+    http::header,
     web::{Data, Json, Path},
 };
 use api_utils::context::WyrmContext;
 use database::{
-    models::feed::Feed,
+    models::{feed::Feed, feed_icon::FeedIcon},
     newtypes::FeedId,
     views::{self, feed::FeedView},
 };
@@ -21,6 +22,23 @@ pub async fn get(path: Path<FeedId>, ctx: Data<WyrmContext>) -> WyrmResult<Json<
 pub async fn list(ctx: Data<WyrmContext>) -> WyrmResult<Json<Vec<FeedView>>> {
     let feeds = views::feed::list(&ctx.db_pool).await?;
     Ok(Json(feeds))
+}
+
+pub async fn icon(path: Path<FeedId>, ctx: Data<WyrmContext>) -> WyrmResult<HttpResponse> {
+    let icon = FeedIcon::get(&ctx.db_pool, path.into_inner()).await?;
+    let Some(FeedIcon {
+        data: Some(data),
+        content_type,
+        ..
+    }) = icon
+    else {
+        return Ok(HttpResponse::NotFound().finish());
+    };
+    Ok(HttpResponse::Ok()
+        .content_type(content_type.unwrap_or_else(|| "image/x-icon".to_string()))
+        // Icons rarely change; spare the repeat requests as post lists render.
+        .insert_header((header::CACHE_CONTROL, "max-age=86400"))
+        .body(data))
 }
 
 pub async fn poll(ctx: Data<WyrmContext>) -> WyrmResult<HttpResponse> {

--- a/api/crud/src/feeds.rs
+++ b/api/crud/src/feeds.rs
@@ -1,11 +1,17 @@
 use actix_web::web::{Data, Json, Path};
 use api_utils::context::WyrmContext;
 use database::{
-    models::feed::{Feed, FeedInsertForm, FeedUpdateForm},
+    models::{
+        feed::{Feed, FeedInsertForm, FeedUpdateForm},
+        feed_icon::FeedIcon,
+    },
     newtypes::FeedId,
 };
 use serde::Deserialize;
-use wyrm_rss::discover::resolve_feed_url;
+use wyrm_rss::{
+    discover::{FetchedUrl, fetch_url, resolve_feed_url},
+    icon::ensure_feed_icon,
+};
 use wyrm_utils::result::WyrmResult;
 
 #[derive(Deserialize, ts_rs::TS)]
@@ -37,9 +43,11 @@ pub async fn create(
     Json(data): Json<CreateFeed>,
     ctx: Data<WyrmContext>,
 ) -> WyrmResult<Json<Feed>> {
-    // A page URL (blog homepage, YouTube channel) resolves to the feed it
-    // advertises; a URL that already serves a feed passes through unchanged.
-    let url = resolve_feed_url(&ctx.http, &data.url).await?;
+    // One fetch serves both discovery and the icon lookup below: we try to
+    // find a feed from a normal page url (blog homepage, YouTube channel),
+    // and if the URL provided already resolves to a feed, we simply pass through.
+    let fetched = fetch_url(&ctx.http, &data.url).await;
+    let url = resolve_feed_url(&data.url, &fetched)?;
     let feed = Feed::create(
         &ctx.db_pool,
         FeedInsertForm {
@@ -51,6 +59,13 @@ pub async fn create(
         },
     )
     .await?;
+
+    // Resolved here when discovery already parsed the feed, so the icon is
+    // stored before the frontend refetches the feed list.
+    if let Some(parsed) = fetched.parsed_feed() {
+        ensure_feed_icon(&ctx.db_pool, &ctx.http, &feed, parsed).await;
+    }
+
     Ok(Json(feed))
 }
 
@@ -62,14 +77,18 @@ pub async fn update(
     let id = path.into_inner();
     // Only a *changed* URL triggers discovery. The edit form always sends the
     // url field, so an unchanged one must pass through without a network
-    // round-trip — otherwise a TTL/title edit would fail while the feed's
+    // round-trip, otherwise a TTL/title edit would fail while the feed's
     // site happens to be down.
     let feed = Feed::get(&ctx.db_pool, id).await?;
-    let url = match data.url {
-        Some(u) if u == feed.url => Some(u),
-        Some(u) => Some(resolve_feed_url(&ctx.http, &u).await?),
-        None => None,
+    let (url, fetched) = match data.url {
+        Some(u) if u == feed.url => (Some(u), FetchedUrl::None),
+        Some(u) => {
+            let fetched = fetch_url(&ctx.http, &u).await;
+            (Some(resolve_feed_url(&u, &fetched)?), fetched)
+        }
+        None => (None, FetchedUrl::None),
     };
+    let url_changed = url.as_deref().is_some_and(|u| u != feed.url);
 
     let feed = Feed::update(
         &ctx.db_pool,
@@ -84,6 +103,17 @@ pub async fn update(
         },
     )
     .await?;
+
+    // When feed url has been updated, we need to delete current icon and
+    // fetch the new one; right away when discovery already parsed the feed,
+    // otherwise at the next poll (the missing row triggers resolution).
+    if url_changed {
+        FeedIcon::delete(&ctx.db_pool, id).await?;
+        if let Some(parsed) = fetched.parsed_feed() {
+            ensure_feed_icon(&ctx.db_pool, &ctx.http, &feed, parsed).await;
+        }
+    }
+
     Ok(Json(feed))
 }
 

--- a/api/routes/src/feeds.rs
+++ b/api/routes/src/feeds.rs
@@ -9,6 +9,7 @@ pub fn config(cfg: &mut web::ServiceConfig) {
             .route("", web::post().to(crud_feeds::create))
             .route("/poll", web::post().to(feeds::poll))
             .route("/{feed_id}", web::get().to(feeds::get))
+            .route("/{feed_id}/icon", web::get().to(feeds::icon))
             .route("/{feed_id}", web::patch().to(crud_feeds::update))
             .route("/{feed_id}", web::delete().to(crud_feeds::delete))
             .route(

--- a/database/src/models/feed_icon.rs
+++ b/database/src/models/feed_icon.rs
@@ -1,0 +1,130 @@
+use crate::{DatabasePool, newtypes::FeedId, schema::feed_icons};
+use chrono::{DateTime, Utc};
+use diesel::{prelude::*, upsert::excluded};
+use diesel_async::RunQueryDsl;
+use wyrm_utils::{error::WyrmError, result::WyrmResult};
+
+/// A feed's resolved icon. One row per feed; `data` is `None` when a lookup
+/// completed but found nothing, so missing icons can be retried on a slow
+/// cadence instead of on every poll.
+#[derive(Queryable, Selectable, Identifiable)]
+#[diesel(table_name = crate::schema::feed_icons)]
+#[diesel(primary_key(feed_id))]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct FeedIcon {
+    pub feed_id: FeedId,
+    /// Raw image bytes; `None` = checked, nothing found.
+    pub data: Option<Vec<u8>>,
+    /// MIME type the bytes are served with.
+    pub content_type: Option<String>,
+    /// When the icon was last (re)resolved.
+    pub checked_at: DateTime<Utc>,
+}
+
+impl FeedIcon {
+    /// `None` = the feed has never been checked for an icon.
+    pub async fn get(pool: &DatabasePool, feed_id: FeedId) -> WyrmResult<Option<Self>> {
+        let mut conn = pool.get().await?;
+        feed_icons::table
+            .find(feed_id)
+            .select(Self::as_select())
+            .first(&mut conn)
+            .await
+            .optional()
+            .map_err(WyrmError::from)
+    }
+
+    /// Records a lookup result. Resolution always writes the latest outcome,
+    /// so an existing row is replaced (`checked_at` bumps either way).
+    pub async fn create(pool: &DatabasePool, form: FeedIconInsertForm) -> WyrmResult<()> {
+        let mut conn = pool.get().await?;
+        diesel::insert_into(feed_icons::table)
+            .values(&form)
+            .on_conflict(feed_icons::feed_id)
+            .do_update()
+            .set((
+                feed_icons::data.eq(excluded(feed_icons::data)),
+                feed_icons::content_type.eq(excluded(feed_icons::content_type)),
+                feed_icons::checked_at.eq(diesel::dsl::now),
+            ))
+            .execute(&mut conn)
+            .await
+            .map_err(WyrmError::from)?;
+        Ok(())
+    }
+
+    /// Drops the stored icon so the next resolution starts fresh; used when a
+    /// feed's URL changes. Deleting a feed cascades the row away on its own.
+    pub async fn delete(pool: &DatabasePool, feed_id: FeedId) -> WyrmResult<()> {
+        let mut conn = pool.get().await?;
+        diesel::delete(feed_icons::table.find(feed_id))
+            .execute(&mut conn)
+            .await
+            .map_err(WyrmError::from)?;
+        Ok(())
+    }
+}
+
+#[derive(Insertable)]
+#[diesel(table_name = crate::schema::feed_icons)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct FeedIconInsertForm {
+    pub feed_id: FeedId,
+    /// `None` records a lookup that found no icon.
+    pub data: Option<Vec<u8>>,
+    pub content_type: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::setup_test_db;
+
+    #[tokio::test]
+    async fn create_replaces_and_get_roundtrips() {
+        let pool = setup_test_db().await;
+        let feed = test_feed!(&pool);
+
+        assert!(FeedIcon::get(&pool, feed.id).await.unwrap().is_none());
+
+        FeedIcon::create(
+            &pool,
+            FeedIconInsertForm {
+                feed_id: feed.id,
+                data: Some(vec![1, 2, 3]),
+                content_type: Some("image/png".into()),
+            },
+        )
+        .await
+        .expect("create should succeed");
+        let icon = FeedIcon::get(&pool, feed.id)
+            .await
+            .unwrap()
+            .expect("icon row should exist");
+        assert_eq!(icon.data.as_deref(), Some(&[1u8, 2, 3][..]));
+        assert_eq!(icon.content_type.as_deref(), Some("image/png"));
+
+        // A later "nothing found" result replaces the row instead of erroring
+        // on the primary key.
+        FeedIcon::create(
+            &pool,
+            FeedIconInsertForm {
+                feed_id: feed.id,
+                data: None,
+                content_type: None,
+            },
+        )
+        .await
+        .expect("create should succeed");
+        let icon = FeedIcon::get(&pool, feed.id)
+            .await
+            .unwrap()
+            .expect("icon row should exist");
+        assert!(icon.data.is_none());
+        assert!(icon.content_type.is_none());
+
+        crate::models::feed::Feed::delete(&pool, feed.id)
+            .await
+            .expect("should delete feed");
+    }
+}

--- a/database/src/models/mod.rs
+++ b/database/src/models/mod.rs
@@ -3,6 +3,7 @@ pub mod feed;
 #[macro_use]
 pub mod post;
 pub mod archive;
+pub mod feed_icon;
 pub mod folder;
 pub mod settings;
 pub mod webhook;

--- a/database/src/schema.rs
+++ b/database/src/schema.rs
@@ -11,6 +11,15 @@ pub mod sql_types {
 }
 
 diesel::table! {
+    feed_icons (feed_id) {
+        feed_id -> Int4,
+        data -> Nullable<Bytea>,
+        content_type -> Nullable<Text>,
+        checked_at -> Timestamptz,
+    }
+}
+
+diesel::table! {
     feed_webhooks (feed_id, webhook_id) {
         feed_id -> Int4,
         webhook_id -> Int4,
@@ -98,12 +107,14 @@ diesel::table! {
     }
 }
 
+diesel::joinable!(feed_icons -> feeds (feed_id));
 diesel::joinable!(feed_webhooks -> feeds (feed_id));
 diesel::joinable!(feed_webhooks -> webhooks (webhook_id));
 diesel::joinable!(feeds -> folders (folder_id));
 diesel::joinable!(posts -> feeds (feed_id));
 
 diesel::allow_tables_to_appear_in_same_query!(
+    feed_icons,
     feed_webhooks,
     feeds,
     folders,

--- a/database/src/views/feed.rs
+++ b/database/src/views/feed.rs
@@ -1,11 +1,13 @@
 use crate::{
     DatabasePool,
     models::feed::Feed,
-    schema::{feeds, posts},
+    newtypes::FeedId,
+    schema::{feed_icons, feeds, posts},
 };
 use diesel::{dsl::count, prelude::*};
 use diesel_async::RunQueryDsl;
 use serde::Serialize;
+use std::collections::HashSet;
 use wyrm_utils::{error::WyrmError, result::WyrmResult};
 
 #[derive(Serialize, ts_rs::TS)]
@@ -14,6 +16,8 @@ pub struct FeedView {
     #[serde(flatten)]
     pub feed: Feed,
     pub unread_count: i64,
+    /// Whether `GET /feeds/{id}/icon` will serve an image.
+    pub has_icon: bool,
 }
 
 /// List of feeds with post unread count
@@ -30,9 +34,22 @@ pub async fn list(pool: &DatabasePool) -> WyrmResult<Vec<FeedView>> {
         .await
         .map_err(WyrmError::from)?;
 
+    let icon_ids: HashSet<FeedId> = feed_icons::table
+        .filter(feed_icons::data.is_not_null())
+        .select(feed_icons::feed_id)
+        .load::<FeedId>(&mut conn)
+        .await
+        .map_err(WyrmError::from)?
+        .into_iter()
+        .collect();
+
     Ok(rows
         .into_iter()
-        .map(|(feed, unread_count)| FeedView { feed, unread_count })
+        .map(|(feed, unread_count)| FeedView {
+            has_icon: icon_ids.contains(&feed.id),
+            feed,
+            unread_count,
+        })
         .collect())
 }
 
@@ -40,8 +57,10 @@ pub async fn list(pool: &DatabasePool) -> WyrmResult<Vec<FeedView>> {
 mod tests {
     use super::*;
     use crate::{
-        models::post::{Post, PostUpdateForm},
-        newtypes::FeedId,
+        models::{
+            feed_icon::{FeedIcon, FeedIconInsertForm},
+            post::{Post, PostUpdateForm},
+        },
         setup_test_db,
     };
 
@@ -75,11 +94,36 @@ mod tests {
         .await
         .expect("should mark post read");
 
+        // Only stored bytes flag has_icon; a "checked, nothing found" row
+        // must not.
+        FeedIcon::create(
+            &pool,
+            FeedIconInsertForm {
+                feed_id: feed.id,
+                data: Some(vec![1]),
+                content_type: Some("image/png".into()),
+            },
+        )
+        .await
+        .expect("should store icon");
+        FeedIcon::create(
+            &pool,
+            FeedIconInsertForm {
+                feed_id: postless_feed.id,
+                data: None,
+                content_type: None,
+            },
+        )
+        .await
+        .expect("should store icon lookup");
+
         let views = list(&pool).await.expect("list should succeed");
         assert_eq!(find(&views, feed.id).unread_count, 2);
         // A feed with no unread rows must survive the left join with a 0,
         // not vanish from the list.
         assert_eq!(find(&views, postless_feed.id).unread_count, 0);
+        assert!(find(&views, feed.id).has_icon);
+        assert!(!find(&views, postless_feed.id).has_icon);
 
         Feed::delete(&pool, feed.id)
             .await

--- a/migrations/2026-07-10-145802-0000_add_feed_icons/down.sql
+++ b/migrations/2026-07-10-145802-0000_add_feed_icons/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE feed_icons;

--- a/migrations/2026-07-10-145802-0000_add_feed_icons/up.sql
+++ b/migrations/2026-07-10-145802-0000_add_feed_icons/up.sql
@@ -1,0 +1,8 @@
+-- Feed icons live in a separate table so the blob never gets pulled with
+-- the feed rows every list query selects. 
+CREATE TABLE feed_icons (
+    feed_id      INTEGER PRIMARY KEY REFERENCES feeds(id) ON DELETE CASCADE,
+    data         BYTEA,
+    content_type TEXT,
+    checked_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/rss/src/discover.rs
+++ b/rss/src/discover.rs
@@ -14,33 +14,72 @@ use scraper::{Html, Selector};
 use tracing::warn;
 use wyrm_utils::{error::WyrmError, result::WyrmResult};
 
-/// Resolves `url` to the feed URL to store. Fails with a client-facing
-/// error only on positive evidence: the page fetched fine and advertises no
-/// feed. An unreachable host passes the URL through unchanged — down is not
-/// invalid (YouTube/Reddit feeds have dead windows), and the poller retries
-/// forever anyway.
-pub async fn resolve_feed_url(http: &HttpClient, url: &str) -> WyrmResult<String> {
+/// What a submitted URL turned out to serve — fetched once by [`fetch_url`],
+/// then shared by feed-URL resolution and icon resolution.
+pub enum FetchedUrl {
+    /// The URL served a feed. Boxed: the parsed feed is ~1 KB, and the enum
+    /// is sized to its largest variant; the other variants shouldn't carry
+    /// that weight.
+    Feed(Box<feed_rs::model::Feed>),
+    /// The URL served something else (typically an HTML page); the body is
+    /// kept for autodiscovery scanning.
+    Html(String),
+    /// Nothing fetched: host unreachable (down is not invalid; YouTube and
+    /// Reddit feeds have dead windows, and the poller retries forever), or
+    /// the URL resolves without a network round-trip (YouTube `/channel/`
+    /// shortcut).
+    None,
+}
+
+impl FetchedUrl {
+    /// The parsed feed, when the URL served one — feeds icon resolution.
+    pub fn parsed_feed(&self) -> Option<&feed_rs::model::Feed> {
+        match self {
+            FetchedUrl::Feed(feed) => Some(feed.as_ref()),
+            _ => None,
+        }
+    }
+}
+
+/// Fetches a submitted URL once and classifies what it serves.
+pub async fn fetch_url(http: &HttpClient, url: &str) -> FetchedUrl {
+    // `/channel/<id>` URLs resolve directly; skip the network round-trip.
+    if youtube_channel_shortcut(url).is_some() {
+        return FetchedUrl::None;
+    }
+
+    let bytes = match http.fetch(url).await {
+        Ok((bytes, _)) => bytes,
+        Err(e) => {
+            warn!("feed discovery: could not fetch {url}: {e}");
+            return FetchedUrl::None;
+        }
+    };
+
+    match feed_rs::parser::parse(&bytes[..]) {
+        Ok(parsed) => FetchedUrl::Feed(Box::new(parsed)),
+        Err(_) => FetchedUrl::Html(String::from_utf8_lossy(&bytes).into_owned()),
+    }
+}
+
+/// Resolves `url` to the feed URL to store, judging by what [`fetch_url`]
+/// found there. Fails with a client-facing error only on positive evidence:
+/// the page fetched fine and advertises no feed. An unfetched URL passes
+/// through unchanged.
+pub fn resolve_feed_url(url: &str, fetched: &FetchedUrl) -> WyrmResult<String> {
     if let Some(feed) = youtube_channel_shortcut(url) {
         return Ok(feed);
     }
 
-    let bytes = match http.fetch(url).await {
-        Ok(bytes) => bytes,
-        Err(e) => {
-            warn!("feed discovery: could not fetch {url}, storing as-is: {e}");
-            return Ok(url.to_string());
-        }
+    let body = match fetched {
+        FetchedUrl::Feed(_) | FetchedUrl::None => return Ok(url.to_string()),
+        FetchedUrl::Html(body) => body,
     };
 
-    if feed_rs::parser::parse(&bytes[..]).is_ok() {
-        return Ok(url.to_string());
-    }
-
-    let body = String::from_utf8_lossy(&bytes);
-    if let Some(href) = find_alternate_link(&body) {
+    if let Some(href) = find_alternate_link(body) {
         return absolutize(url, &href);
     }
-    if let Some(id) = find_channel_id(&body) {
+    if let Some(id) = find_channel_id(body) {
         return Ok(youtube_feed_url(id));
     }
 
@@ -112,6 +151,45 @@ fn absolutize(base: &str, href: &str) -> WyrmResult<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn resolve_judges_by_fetched_classification() {
+        // A URL that already serves a feed (or couldn't be fetched) passes
+        // through unchanged.
+        let rss = feed_rs::parser::parse(
+            &br#"<rss version="2.0"><channel><title>t</title></channel></rss>"#[..],
+        )
+        .expect("minimal rss should parse");
+        assert_eq!(
+            resolve_feed_url("https://example.com/feed", &FetchedUrl::Feed(Box::new(rss))).unwrap(),
+            "https://example.com/feed"
+        );
+        assert_eq!(
+            resolve_feed_url("https://example.com/feed", &FetchedUrl::None).unwrap(),
+            "https://example.com/feed"
+        );
+
+        // An HTML page resolves through its autodiscovery link; one that
+        // advertises no feed is the only hard failure.
+        let html = r#"<link rel="alternate" type="application/rss+xml" href="/feed.xml">"#;
+        assert_eq!(
+            resolve_feed_url("https://example.com/blog", &FetchedUrl::Html(html.into())).unwrap(),
+            "https://example.com/feed.xml"
+        );
+        assert!(
+            resolve_feed_url("https://example.com", &FetchedUrl::Html("<p>hi</p>".into())).is_err()
+        );
+
+        // The /channel/ shortcut wins regardless of what was (not) fetched.
+        assert_eq!(
+            resolve_feed_url(
+                "https://www.youtube.com/channel/UCVBlOjOg74sx8Gk8Zjmjyrg",
+                &FetchedUrl::None
+            )
+            .unwrap(),
+            "https://www.youtube.com/feeds/videos.xml?channel_id=UCVBlOjOg74sx8Gk8Zjmjyrg"
+        );
+    }
 
     #[test]
     fn channel_url_rewrites_without_fetching() {

--- a/rss/src/http.rs
+++ b/rss/src/http.rs
@@ -85,7 +85,9 @@ impl HttpClient {
         Ok(HttpClient { inner: client })
     }
 
-    pub async fn fetch(&self, url: &str) -> WyrmResult<Bytes> {
+    /// Fetches `url`, returning the body and the response's `Content-Type`
+    /// header (stripped of parameters like `; charset=`).
+    pub async fn fetch(&self, url: &str) -> WyrmResult<(Bytes, Option<String>)> {
         let mut response = self.inner.get(url).send().await?;
 
         if response
@@ -95,6 +97,12 @@ impl HttpClient {
             return Err(HttpClientError::ResponseTooLarge(MAX_RESPONSE_BYTES).into());
         }
 
+        let content_type = response
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .map(|v| v.split(';').next().unwrap_or(v).trim().to_ascii_lowercase());
+
         let mut body = BytesMut::new();
         while let Some(chunk) = response.chunk().await? {
             if body.len() + chunk.len() > MAX_RESPONSE_BYTES {
@@ -103,7 +111,7 @@ impl HttpClient {
             body.extend_from_slice(&chunk);
         }
 
-        Ok(body.freeze())
+        Ok((body.freeze(), content_type))
     }
 
     pub async fn post_json(&self, url: &str, body: &serde_json::Value) -> WyrmResult<()> {

--- a/rss/src/icon.rs
+++ b/rss/src/icon.rs
@@ -1,0 +1,234 @@
+//! Feed icon resolution: finds a small image to represent a feed in the UI.
+//!
+//! The resolution order:
+//!  1. The feed's own `<icon>`/`<logo>`;
+//!  2. The `<link rel="icon">` tags of the site page the feed links to;
+//!  3. `/favicon.ico` at the site origin.
+//!
+//! Every candidate is fetched and validated before it is stored,
+//! so a 404 page served for a missing favicon never ends up in the database.
+
+use crate::http::HttpClient;
+use chrono::{Duration, Utc};
+use database::{
+    DatabasePool,
+    models::{
+        feed::Feed,
+        feed_icon::{FeedIcon, FeedIconInsertForm},
+    },
+};
+use scraper::{Html, Selector};
+use tracing::warn;
+
+/// Favicons run a few KB.
+/// Anything larger is not an icon worth storing and serving per feed.
+const MAX_ICON_BYTES: usize = 256 * 1024;
+
+/// How long a "checked, nothing found" result suppresses re-resolution.
+const RETRY_MISSING_AFTER: Duration = Duration::days(7);
+
+/// Brings `feed`'s stored icon up to date: resolves and stores one if the
+/// feed was never checked, or a previous check found nothing more than
+/// [`RETRY_MISSING_AFTER`] ago. Best-effort by design — failures are logged,
+/// never propagated, because a missing favicon must not fail feed creation
+/// or a poll. Callers without a parsed feed at hand simply skip the call:
+/// the next poll parses one and lands here anyway.
+pub async fn ensure_feed_icon(
+    pool: &DatabasePool,
+    http: &HttpClient,
+    feed: &Feed,
+    parsed: &feed_rs::model::Feed,
+) {
+    let existing = match FeedIcon::get(pool, feed.id).await {
+        Ok(existing) => existing,
+        Err(_) => return,
+    };
+
+    // Found icons are kept until the feed's URL changes (the row is deleted
+    // then); recent misses wait out the retry window.
+    if existing.is_some_and(|icon| {
+        icon.data.is_some() || Utc::now() - icon.checked_at < RETRY_MISSING_AFTER
+    }) {
+        return;
+    }
+
+    let (data, content_type) = resolve_icon(http, &feed.url, parsed).await.unzip();
+    let form = FeedIconInsertForm {
+        feed_id: feed.id,
+        data,
+        content_type,
+    };
+    if let Err(e) = FeedIcon::create(pool, form).await {
+        warn!("feed icon: could not store result for {}: {e}", feed.url);
+    }
+}
+
+/// Runs the source cascade and returns the first candidate that fetches and
+/// validates as an image, as `(bytes, mime)`.
+async fn resolve_icon(
+    http: &HttpClient,
+    feed_url: &str,
+    parsed: &feed_rs::model::Feed,
+) -> Option<(Vec<u8>, String)> {
+    // The feed's own icon/logo elements.
+    for image in [parsed.icon.as_ref(), parsed.logo.as_ref()]
+        .into_iter()
+        .flatten()
+    {
+        if let Some(icon) = fetch_icon(http, feed_url, &image.uri).await {
+            return Some(icon);
+        }
+    }
+
+    // The site page the feed links to.
+    let page_url = site_url(feed_url, parsed);
+    if let Some(page_url) = &page_url
+        && let Ok((bytes, _)) = http.fetch(page_url).await
+    {
+        let body = String::from_utf8_lossy(&bytes);
+        for href in page_icon_candidates(&body) {
+            if let Some(icon) = fetch_icon(http, page_url, &href).await {
+                return Some(icon);
+            }
+        }
+    }
+
+    // Most sites serve /favicon.ico even without advertising it.
+    fetch_icon(
+        http,
+        page_url.as_deref().unwrap_or(feed_url),
+        "/favicon.ico",
+    )
+    .await
+}
+
+/// The site page to scan for icons: the feed's first non-self link (the
+/// channel/home page for YouTube and most blogs), or `None` when the feed
+/// links nowhere and only the origin favicon fallback remains.
+fn site_url(feed_url: &str, parsed: &feed_rs::model::Feed) -> Option<String> {
+    parsed
+        .links
+        .iter()
+        .find(|link| link.rel.as_deref() != Some("self"))
+        .and_then(|link| join_url(feed_url, &link.href))
+}
+
+/// Icon URL candidates advertised by an HTML page, in document order.
+/// `og:image` is deliberately not considered: it is a share banner (or, on
+/// YouTube, the channel avatar), not the site's icon.
+fn page_icon_candidates(html: &str) -> Vec<String> {
+    // rel is a space-separated token list, so ~= also matches "shortcut icon".
+    let selector = Selector::parse(r#"link[rel~="icon" i], link[rel~="apple-touch-icon" i]"#)
+        .expect("static selector is valid");
+    Html::parse_document(html)
+        .select(&selector)
+        .filter_map(|link| link.value().attr("href").map(String::from))
+        .collect()
+}
+
+async fn fetch_icon(http: &HttpClient, base: &str, href: &str) -> Option<(Vec<u8>, String)> {
+    let url = join_url(base, href)?;
+    let (bytes, content_type) = http.fetch(&url).await.ok()?;
+    if bytes.is_empty() || bytes.len() > MAX_ICON_BYTES {
+        return None;
+    }
+    let mime = sniff_image(&bytes)
+        .map(String::from)
+        .or(content_type.filter(|ct| ct.starts_with("image/")))?;
+    Some((bytes.to_vec(), mime))
+}
+
+/// Identifies an image format from its leading bytes.
+/// https://en.wikipedia.org/wiki/List_of_file_signatures
+fn sniff_image(bytes: &[u8]) -> Option<&'static str> {
+    if bytes.starts_with(b"\x89PNG\r\n\x1a\n") {
+        return Some("image/png");
+    }
+    if bytes.starts_with(b"\xff\xd8\xff") {
+        return Some("image/jpeg");
+    }
+    if bytes.starts_with(b"GIF87a") || bytes.starts_with(b"GIF89a") {
+        return Some("image/gif");
+    }
+    if bytes.starts_with(b"\x00\x00\x01\x00") {
+        return Some("image/x-icon");
+    }
+    if bytes.starts_with(b"RIFF") && bytes.get(8..12) == Some(b"WEBP".as_slice()) {
+        return Some("image/webp");
+    }
+    // SVG has no magic number; accept only documents that open as SVG/XML,
+    // not arbitrary text that merely mentions an <svg> tag somewhere.
+    let head = std::str::from_utf8(&bytes[..bytes.len().min(1024)]).ok()?;
+    let head = head.trim_start_matches('\u{feff}').trim_start();
+    if head.starts_with("<svg") || (head.starts_with("<?xml") && head.contains("<svg")) {
+        return Some("image/svg+xml");
+    }
+    None
+}
+
+/// Resolves a possibly-relative `href` against `base`.
+fn join_url(base: &str, href: &str) -> Option<String> {
+    reqwest::Url::parse(base)
+        .and_then(|b| b.join(href))
+        .map(String::from)
+        .ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sniffs_common_formats_and_rejects_garbage() {
+        assert_eq!(sniff_image(b"\x89PNG\r\n\x1a\n...."), Some("image/png"));
+        assert_eq!(sniff_image(b"\xff\xd8\xff\xe0...."), Some("image/jpeg"));
+        assert_eq!(sniff_image(b"GIF89a...."), Some("image/gif"));
+        assert_eq!(sniff_image(b"\x00\x00\x01\x00...."), Some("image/x-icon"));
+        assert_eq!(
+            sniff_image(b"RIFF\x00\x00\x00\x00WEBPVP8 "),
+            Some("image/webp")
+        );
+        assert_eq!(
+            sniff_image(b"<svg xmlns=\"http://www.w3.org/2000/svg\"/>"),
+            Some("image/svg+xml")
+        );
+        assert_eq!(
+            sniff_image(b"<?xml version=\"1.0\"?><svg/>"),
+            Some("image/svg+xml")
+        );
+
+        assert_eq!(sniff_image(b""), None);
+        assert_eq!(sniff_image(b"<html><body>404</body></html>"), None);
+        // Text mentioning <svg> mid-document is not an SVG.
+        assert_eq!(sniff_image(b"<html>an inline <svg/> here</html>"), None);
+    }
+
+    #[test]
+    fn page_candidates_cover_icon_rel_variants_in_order() {
+        let html = r#"
+            <link rel="stylesheet" href="/style.css">
+            <link rel="shortcut icon" href="/favicon.ico">
+            <LINK REL="Icon" HREF="/favicon-32.png" SIZES="32x32">
+            <link rel="apple-touch-icon" href="/touch.png">
+            <meta property="og:image" content="/banner.png">
+        "#;
+        // og:image is a share banner (or channel avatar), not an icon.
+        assert_eq!(
+            page_icon_candidates(html),
+            vec!["/favicon.ico", "/favicon-32.png", "/touch.png"]
+        );
+    }
+
+    #[test]
+    fn join_url_resolves_relative_and_absolute() {
+        assert_eq!(
+            join_url("https://example.com/blog/feed.xml", "/favicon.ico").as_deref(),
+            Some("https://example.com/favicon.ico")
+        );
+        assert_eq!(
+            join_url("https://example.com/", "https://cdn.example.com/icon.png").as_deref(),
+            Some("https://cdn.example.com/icon.png")
+        );
+        assert_eq!(join_url("nonsense", "/favicon.ico"), None);
+    }
+}

--- a/rss/src/lib.rs
+++ b/rss/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod discover;
 pub mod filter;
 pub mod http;
+pub mod icon;
 pub mod opml;
 pub mod worker;

--- a/rss/src/worker.rs
+++ b/rss/src/worker.rs
@@ -141,9 +141,13 @@ pub struct FeedTask {
 async fn process_feed(pool: &DatabasePool, http: &HttpClient, task: &FeedTask) -> WyrmResult<()> {
     info!("Processing feed {}", task.feed.title);
 
-    let bytes = http.fetch(&task.feed.url).await?;
+    let (bytes, _) = http.fetch(&task.feed.url).await?;
 
     let parsed = feed_rs::parser::parse(&bytes[..])?;
+
+    // Best-effort: resolves the icon for feeds that never got one (OPML
+    // imports, pre-icon feeds) and retries week-old misses.
+    crate::icon::ensure_feed_icon(pool, http, &task.feed, &parsed).await;
 
     let filters = CompiledFilters::new(&task.feed.filters);
 

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1279,6 +1279,25 @@
   flex-shrink: 0;
 }
 
+/* Muted at rest so icons read as metadata next to the title, not content;
+   full color returns when the row is hovered or active. */
+.post-item-icon {
+  width: 14px;
+  height: 14px;
+  border-radius: 3px;
+  object-fit: cover;
+  flex-shrink: 0;
+  opacity: 0.75;
+  filter: grayscale(0.4);
+  transition: opacity 0.15s ease, filter 0.15s ease;
+}
+
+.post-item:hover .post-item-icon,
+.post-item.active .post-item-icon {
+  opacity: 1;
+  filter: none;
+}
+
 
 .post-item-title {
   flex: 1;

--- a/web/src/api/feeds.ts
+++ b/web/src/api/feeds.ts
@@ -3,14 +3,19 @@ import type { FeedView } from "../types/FeedView";
 import type { FeedId } from "../types/FeedId";
 import type { CreateFeed } from "../types/CreateFeed";
 import type { UpdateFeed } from "../types/UpdateFeed";
-import { ENDPOINTS, json, noContent } from "../utils/api";
+import { ENDPOINTS } from "../utils/api";
 import { fetchWithAuth } from "../utils/auth";
+import { blob, json, noContent } from "../utils/response";
 
 export const getFeeds = (): Promise<FeedView[]> =>
   fetchWithAuth(ENDPOINTS.feeds.list()).then<FeedView[]>(json);
 
 export const getFeed = (id: FeedId): Promise<Feed> =>
   fetchWithAuth(ENDPOINTS.feeds.get(id)).then<Feed>(json);
+
+export const getFeedIcon = (id: FeedId): Promise<Blob> =>
+  fetchWithAuth(ENDPOINTS.feeds.icon(id)).then(blob);
+
 
 export const createFeed = (body: CreateFeed): Promise<Feed> =>
   fetchWithAuth(ENDPOINTS.feeds.create(), {

--- a/web/src/api/folders.ts
+++ b/web/src/api/folders.ts
@@ -1,9 +1,11 @@
-import { ApiError, ENDPOINTS, json } from "../utils/api";
+import { ENDPOINTS } from "../utils/api";
 import { fetchWithAuth } from "../utils/auth";
 import type { Folder } from "../types/Folder";
 import type { FolderId } from "../types/FolderId";
 import type { CreateFolder } from "../types/CreateFolder";
 import type { UpdateFolder } from "../types/UpdateFolder";
+import { json } from "../utils/response";
+import { ApiError } from "../utils/error";
 
 export const getFolders = (): Promise<Folder[]> =>
   fetchWithAuth(ENDPOINTS.folders.list()).then<Folder[]>(json);

--- a/web/src/api/posts.ts
+++ b/web/src/api/posts.ts
@@ -4,10 +4,11 @@ import type { PagedResponse } from "../types/PagedResponse";
 import type { UpdatePost } from "../types/UpdatePost";
 import type { UpdatePostResponse } from "../types/UpdatePostResponse";
 import type { ListPosts } from "../types/ListPosts";
-import { ENDPOINTS, json, noContent } from "../utils/api";
+import { ENDPOINTS } from "../utils/api";
 import type { ListPostArchive } from "../types/ListPostArchive";
 import type { PostArchive } from "../types/PostArchive";
 import { fetchWithAuth } from "../utils/auth";
+import { json, noContent } from "../utils/response";
 
 export const listPosts = (params: ListPosts): Promise<PagedResponse<Array<Post>>> =>
   fetchWithAuth(ENDPOINTS.posts.list(params)).then<PagedResponse<Array<Post>>>(json);

--- a/web/src/api/settings.ts
+++ b/web/src/api/settings.ts
@@ -1,7 +1,8 @@
 import type { Settings } from "../types/Settings";
 import type { UpdateSettings } from "../types/UpdateSettings";
-import { ENDPOINTS, json, noContent } from "../utils/api";
+import { ENDPOINTS } from "../utils/api";
 import { fetchWithAuth } from "../utils/auth";
+import { json, noContent } from "../utils/response";
 
 export const getSettings = (): Promise<Settings> =>
   fetchWithAuth(ENDPOINTS.settings.get()).then(json<Settings>);

--- a/web/src/api/webhooks.ts
+++ b/web/src/api/webhooks.ts
@@ -3,8 +3,9 @@ import type { FeedId } from "../types/FeedId";
 import type { WebhookId } from "../types/WebhookId";
 import type { CreateWebhook } from "../types/CreateWebhook";
 import type { UpdateWebhook } from "../types/UpdateWebhook";
-import { ENDPOINTS, json, noContent } from "../utils/api";
+import { ENDPOINTS } from "../utils/api";
 import { fetchWithAuth } from "../utils/auth";
+import { json, noContent } from "../utils/response";
 
 export const getWebhooks = (): Promise<Webhook[]> =>
   fetchWithAuth(ENDPOINTS.webhooks.list()).then<Webhook[]>(json);

--- a/web/src/components/PostItem.tsx
+++ b/web/src/components/PostItem.tsx
@@ -3,12 +3,16 @@ import { Link } from "react-router-dom";
 import { HiMail, HiMailOpen } from "react-icons/hi";
 import { TbArchive, TbArchiveOff, TbBookmark, TbBookmarkFilled } from "react-icons/tb";
 import type { Post } from "../types/Post";
+import type { FeedId } from "../types/FeedId";
 import { useArchivePost, useUnarchivePost, useSetPostRead, useSetPostBookmarked } from "../hooks/usePostMutations";
 import { useSettings } from "../hooks/useSettings";
+import { useFeedIcon } from "../hooks/useFeeds";
 import { initials } from "../utils/posts";
 
 export interface FeedMeta {
+  id: FeedId;
   name: string;
+  hasIcon: boolean;
 }
 
 interface Props {
@@ -24,6 +28,7 @@ export const PostItem = memo(function PostItem({ post, to, active, feed }: Props
   const { mutate: archivePost } = useArchivePost();
   const { mutate: unarchivePost } = useUnarchivePost();
   const { data: settings } = useSettings();
+  const iconUrl = useFeedIcon(feed);
   const readMode = settings?.read_mode ?? "on_open";
   const isRead = readMode === "disabled" ? true : post.is_read;
 
@@ -69,7 +74,12 @@ export const PostItem = memo(function PostItem({ post, to, active, feed }: Props
           {mailIcon}
         </button>
       )}
-      {feed && <span className="post-item-feed">{initials(feed.name)}</span>}
+      {feed &&
+        (iconUrl ? (
+          <img className="post-item-icon" src={iconUrl} alt="" loading="lazy" />
+        ) : (
+          <span className="post-item-feed">{initials(feed.name)}</span>
+        ))}
       <span className="post-item-title">{post.title ?? "Untitled"}</span>
       <button
         className={`post-item-archive${post.is_archived ? " archived" : ""}`}

--- a/web/src/hooks/useFeedMap.ts
+++ b/web/src/hooks/useFeedMap.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import type { Feed } from "../types/Feed";
+import type { FeedView } from "../types/FeedView";
 import type { FeedId } from "../types/FeedId";
 import type { FeedMeta } from "../components/PostItem";
 
@@ -7,11 +7,14 @@ import type { FeedMeta } from "../components/PostItem";
  * Maps feed id - display metadata for post rows. Memoised so the FeedMeta
  * object references stay stable between renders and React.memo on PostItem can bail out
  */
-export function useFeedMap(feeds: Feed[] | undefined): Map<FeedId, FeedMeta> {
+export function useFeedMap(feeds: FeedView[] | undefined): Map<FeedId, FeedMeta> {
   return useMemo(
     () =>
       new Map(
-        (feeds ?? []).map((f): [FeedId, FeedMeta] => [f.id, { name: f.title }])
+        (feeds ?? []).map((f): [FeedId, FeedMeta] => [
+          f.id,
+          { id: f.id, name: f.title, hasIcon: f.has_icon },
+        ])
       ),
     [feeds]
   );

--- a/web/src/hooks/useFeeds.ts
+++ b/web/src/hooks/useFeeds.ts
@@ -1,11 +1,12 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { createFeed, deleteFeed, getFeeds, pollFeeds, updateFeed } from "../api/feeds";
+import { createFeed, deleteFeed, getFeedIcon, getFeeds, pollFeeds, updateFeed } from "../api/feeds";
 import { feedKeys } from "../cache/feeds";
 import { postKeys } from "../cache/posts";
 import { folderKeys } from "./useFolders";
 import type { CreateFeed } from "../types/CreateFeed";
 import type { UpdateFeed } from "../types/UpdateFeed";
 import type { FeedId } from "../types/FeedId";
+import type { FeedMeta } from "../components/PostItem";
 
 export function useFeeds() {
   return useQuery({
@@ -17,6 +18,25 @@ export function useFeeds() {
     // until the next user action or reload.
     staleTime: Infinity,
   });
+}
+
+/**
+ * Object URL for a feed's icon, or `undefined` while it loads / when the
+ * feed has none (render the initials fallback then). The blob is fetched
+ * with auth once per feed and shared by every post row via the query cache;
+ * the key sits outside `feedKeys.all` so feed mutations don't refetch icons.
+ */
+export function useFeedIcon(feed?: FeedMeta): string | undefined {
+  const { data } = useQuery({
+    queryKey: ["feed-icon", feed?.id],
+    queryFn: () => getFeedIcon(feed!.id).then(URL.createObjectURL),
+    enabled: !!feed?.hasIcon,
+    // Object URLs stay valid for the whole session; never refetch or evict
+    // (eviction would leak the URL without revoking it).
+    staleTime: Infinity,
+    gcTime: Infinity,
+  });
+  return data;
 }
 
 export function useCreateFeed() {

--- a/web/src/types/FeedView.ts
+++ b/web/src/types/FeedView.ts
@@ -2,7 +2,11 @@
 import type { FeedId } from "./FeedId";
 import type { FolderId } from "./FolderId";
 
-export type FeedView = { unread_count: number, id: FeedId, 
+export type FeedView = { unread_count: number, 
+/**
+ * Whether `GET /feeds/{id}/icon` will serve an image.
+ */
+has_icon: boolean, id: FeedId, 
 /**
  * Human-readable feed name shown in the UI.
  */

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -3,7 +3,6 @@ import type { ListPosts } from "../types/ListPosts";
 import type { FeedId } from "../types/FeedId";
 import type { PostId } from "../types/PostId";
 import type { WebhookId } from "../types/WebhookId";
-import { handleUnauthorized } from "./auth";
 import type { FolderId } from "../types/FolderId";
 
 const BASE = "/api/v1";
@@ -21,6 +20,7 @@ export const ENDPOINTS = {
     list: () => `${BASE}/feeds`,
     create: () => `${BASE}/feeds`,
     get: (id: FeedId) => `${BASE}/feeds/${id}`,
+    icon: (id: FeedId) => `${BASE}/feeds/${id}/icon`,
     update: (id: FeedId) => `${BASE}/feeds/${id}`,
     delete: (id: FeedId) => `${BASE}/feeds/${id}`,
     poll: () => `${BASE}/feeds/poll`,
@@ -71,36 +71,3 @@ export const ENDPOINTS = {
       `${BASE}/feeds/${feedId}/webhooks/${webhookId}`,
   },
 } as const;
-
-
-/** API failure carrying the status and the server's curated `error` message. */
-export class ApiError extends Error {
-  status: number;
-
-  constructor(status: number, message: string) {
-    super(message);
-    this.status = status;
-  }
-}
-
-async function throwApiError(res: Response): Promise<never> {
-  const body = (await res.json().catch(() => undefined)) as { error?: string } | undefined;
-  throw new ApiError(res.status, body?.error ?? `${res.status} ${res.statusText}`);
-}
-
-export async function json<T>(res: Response): Promise<T> {
-  if (res.status === 401) {
-    handleUnauthorized();
-    throw new Error("Unauthorized");
-  }
-  if (!res.ok) await throwApiError(res);
-  return res.json();
-}
-
-export async function noContent(res: Response): Promise<void> {
-  if (res.status === 401) {
-    handleUnauthorized();
-    throw new Error("Unauthorized");
-  }
-  if (!res.ok) await throwApiError(res);
-}

--- a/web/src/utils/error.ts
+++ b/web/src/utils/error.ts
@@ -1,0 +1,15 @@
+/** API failure carrying the status and the server's curated `error` message. */
+export class ApiError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+  }
+}
+
+export async function throwApiError(res: Response): Promise<never> {
+  const body = (await res.json().catch(() => undefined)) as { error?: string } | undefined;
+  throw new ApiError(res.status, body?.error ?? `${res.status} ${res.statusText}`);
+}
+

--- a/web/src/utils/response.ts
+++ b/web/src/utils/response.ts
@@ -1,0 +1,26 @@
+import { handleUnauthorized } from "./auth";
+import { throwApiError } from "./error";
+
+export async function json<T>(res: Response): Promise<T> {
+  isUnauthorized(res);
+  if (!res.ok) await throwApiError(res);
+  return res.json();
+}
+
+export async function noContent(res: Response): Promise<void> {
+  isUnauthorized(res);
+  if (!res.ok) await throwApiError(res);
+}
+
+export async function blob(res: Response): Promise<Blob> {
+  isUnauthorized(res);
+  if (!res.ok) await throwApiError(res);
+  return res.blob();
+}
+
+function isUnauthorized(res: Response) {
+  if (res.status === 401) {
+    handleUnauthorized();
+    throw new Error("Unauthorized");
+  }
+}


### PR DESCRIPTION
Resolves a favicon per feed and displays it on post rows instead of the feed-initials chip.