### PR TITLE
feat: wait for the post-import poll before responding

### DIFF
--- a/api/api/src/feeds.rs
+++ b/api/api/src/feeds.rs
@@ -55,7 +55,9 @@ pub async fn poll(ctx: Data<WyrmContext>) -> WyrmResult<HttpResponse> {
         Ok(_) => {}
     }
 
-    match tokio::time::timeout(Duration::from_secs(30), rx).await {
+    // Wait for the configured http timeout.
+    let http_timeout = ctx.runtime_settings.read()?.http_timeout;
+    match tokio::time::timeout(Duration::from_secs(http_timeout as u64), rx).await {
         Ok(_) => Ok(HttpResponse::Ok().finish()),
         Err(_) => Ok(HttpResponse::GatewayTimeout().finish()),
     }

--- a/api/api/src/settings.rs
+++ b/api/api/src/settings.rs
@@ -11,7 +11,7 @@ use database::{
     },
     newtypes::FolderId,
 };
-use std::collections::HashMap;
+use std::{collections::HashMap, time::Duration};
 use wyrm_rss::{
     opml::{Opml, Outline},
     worker::WorkerCommand,
@@ -27,7 +27,8 @@ pub async fn get(ctx: Data<WyrmContext>) -> WyrmResult<Json<Settings>> {
 }
 
 /// Imports feeds from a raw OPML request body. Duplicate URLs are skipped;
-/// all other errors propagate. Triggers a best-effort poll after import.
+/// all other errors propagate. Triggers a best-effort poll after import and
+/// waits for it (bounded by one http timeout) before responding.
 pub async fn import(body: web::Bytes, ctx: Data<WyrmContext>) -> WyrmResult<HttpResponse> {
     let opml = Opml::from_xml(body.as_ref())?;
 
@@ -47,8 +48,15 @@ pub async fn import(body: web::Bytes, ctx: Data<WyrmContext>) -> WyrmResult<Http
         }
     }
 
-    let (tx, _) = tokio::sync::oneshot::channel();
+    let (tx, rx) = tokio::sync::oneshot::channel();
     let _ = ctx.worker_tx.try_send(WorkerCommand::PollFeeds(tx));
+
+    // The import is complete and a poll is on the way: give it up to one
+    // http timeout to land so the frontend's refetch right after this
+    // response already sees the imported posts and their icons. A huge
+    // import may take longer; the frontend polls again as a safety net.
+    let http_timeout = ctx.runtime_settings.read()?.http_timeout;
+    let _ = tokio::time::timeout(Duration::from_secs(http_timeout as u64), rx).await;
 
     Ok(HttpResponse::NoContent().finish())
 }

--- a/web/src/components/settings/Opml.tsx
+++ b/web/src/components/settings/Opml.tsx
@@ -50,7 +50,7 @@ export function Opml() {
       <p className="settings-hint">
         Tags are inferred from OPML folders. Feeds with duplicate URLs are skipped.
       </p>
-      {isPending && <p className="settings-status">Importing...</p>}
+      {isPending && <p className="settings-status">Importing and fetching posts...</p>}
       {isSuccess && <p className="settings-status settings-status-ok">Import complete.</p>}
       {isError && <p className="settings-status settings-status-err">Import failed.</p>}
 

--- a/web/src/hooks/useSettings.ts
+++ b/web/src/hooks/useSettings.ts
@@ -32,11 +32,11 @@ export function useImportOpml() {
       qc.invalidateQueries({ queryKey: feedKeys.all });
       // Import resolves-or-creates folders from OPML categories.
       qc.invalidateQueries({ queryKey: folderKeys.all });
-      // The server kicks off a background poll for the imported feeds but the
-      // import response doesn't wait for it. Poll again through the API purely
-      // to learn when it finishes (the worker queue is sequential, and
-      // re-polling already-fetched feeds is a no-op), then pull in the new
-      // posts and unread counts.
+      // The import response waits (bounded) for the post-import poll, so the
+      // invalidations above usually land with posts and icons already there.
+      // Poll again as a safety net for huge imports that outlast the server's
+      // wait (the worker queue is sequential, and re-polling already-fetched
+      // feeds is a no-op), then pull in the new posts and unread counts.
       const refresh = () => {
         qc.invalidateQueries({ queryKey: postKeys.all });
         qc.invalidateQueries({ queryKey: feedKeys.all });


### PR DESCRIPTION
OPML import now waits before returning until the triggered poll lands (up to the http timeout configured), so the frontend's refetch right after importing already sees the new posts and their icons instead of empty feeds that fill in later.