### PR TITLE
fix: deleted posts are re-imported as unread

### DIFF
--- a/database/src/models/expired.rs
+++ b/database/src/models/expired.rs
@@ -1,0 +1,134 @@
+use crate::{DatabaseConn, newtypes::FeedId, schema::expired_posts};
+use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
+use std::collections::HashSet;
+use wyrm_utils::{error::WyrmError, result::WyrmResult};
+
+/// History of expired (deleted) posts to prevent re-fetching.
+/// Without this table, an expired post still advertised by the upstream feed
+/// would be re-inserted as new on every poll, so `Post::create_many` drops
+/// any incoming form recorded here. Rows cascade away with their feed,
+/// so re-adding a feed starts with a clean state.
+#[derive(Queryable, Selectable)]
+#[diesel(table_name = crate::schema::expired_posts)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct ExpiredPost {
+    pub feed_id: FeedId,
+    pub url: String,
+}
+
+impl ExpiredPost {
+    /// Records deleted posts on an existing connection so `Post::expire`'s
+    /// delete + record transaction are atomic. Re-adding an already
+    /// recorded pair is a silent no-op (`ON CONFLICT DO NOTHING`).
+    pub async fn create_many_on(
+        mut conn: &DatabaseConn,
+        forms: Vec<ExpiredPostInsertForm>,
+    ) -> WyrmResult<usize> {
+        diesel::insert_into(expired_posts::table)
+            .values(&forms)
+            .on_conflict_do_nothing()
+            .execute(&mut conn)
+            .await
+            .map_err(WyrmError::from)
+    }
+
+    /// Which of the candidate `(feed_id, url)` pairs are recorded as expired.
+    /// Runs on an existing connection so `Post::create_many` doesn't need a
+    /// second pool checkout.
+    pub async fn matching(
+        mut conn: &DatabaseConn,
+        feed_ids: Vec<FeedId>,
+        urls: Vec<&str>,
+    ) -> WyrmResult<HashSet<(FeedId, String)>> {
+        expired_posts::table
+            .filter(expired_posts::feed_id.eq_any(feed_ids))
+            .filter(expired_posts::url.eq_any(urls))
+            .select((expired_posts::feed_id, expired_posts::url))
+            .load::<(FeedId, String)>(&mut conn)
+            .await
+            .map(|rows| rows.into_iter().collect())
+            .map_err(WyrmError::from)
+    }
+}
+
+#[derive(Insertable)]
+#[diesel(table_name = crate::schema::expired_posts)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct ExpiredPostInsertForm {
+    pub feed_id: FeedId,
+    pub url: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{models::feed::Feed, setup_test_db};
+
+    macro_rules! unique_url {
+        () => {
+            format!(
+                "https://example.com/expired/{}",
+                chrono::Utc::now()
+                    .timestamp_nanos_opt()
+                    .expect("timestamp in range")
+            )
+        };
+    }
+
+    #[tokio::test]
+    async fn create_skips_conflicts_matching_is_exact_and_feed_delete_cascades() {
+        let pool = setup_test_db().await;
+        let feed = test_feed!(&pool);
+        let other_feed = test_feed!(&pool);
+        let url_a = unique_url!();
+        let url_b = unique_url!();
+
+        let conn = pool.get().await.expect("should get conn");
+        let forms = vec![
+            ExpiredPostInsertForm {
+                feed_id: feed.id,
+                url: url_a.clone(),
+            },
+            ExpiredPostInsertForm {
+                feed_id: feed.id,
+                url: url_b.clone(),
+            },
+        ];
+        assert_eq!(ExpiredPost::create_many_on(&conn, forms).await.unwrap(), 2);
+
+        // Same (feed_id, url) hits ON CONFLICT DO NOTHING: no error, no dup.
+        let dup = vec![ExpiredPostInsertForm {
+            feed_id: feed.id,
+            url: url_a.clone(),
+        }];
+        assert_eq!(ExpiredPost::create_many_on(&conn, dup).await.unwrap(), 0);
+
+        // Exact pairs only: other_feed and an unknown url appear in the
+        // filters, but neither (other_feed, url_a) nor (feed, unknown) is a
+        // row in the table.
+        let hits = ExpiredPost::matching(
+            &conn,
+            vec![feed.id, other_feed.id],
+            vec![url_a.as_str(), "https://example.com/never-expired"],
+        )
+        .await
+        .unwrap();
+        assert_eq!(hits.len(), 1);
+        assert!(hits.contains(&(feed.id, url_a.clone())));
+
+        // Deleting the feed cascades its expired-post records away.
+        Feed::delete(&pool, feed.id)
+            .await
+            .expect("should delete feed");
+        let hits =
+            ExpiredPost::matching(&conn, vec![feed.id], vec![url_a.as_str(), url_b.as_str()])
+                .await
+                .unwrap();
+        assert!(hits.is_empty());
+
+        Feed::delete(&pool, other_feed.id)
+            .await
+            .expect("should delete feed");
+    }
+}

--- a/database/src/models/mod.rs
+++ b/database/src/models/mod.rs
@@ -3,6 +3,7 @@ pub mod feed;
 #[macro_use]
 pub mod post;
 pub mod archive;
+pub mod expired;
 pub mod feed_icon;
 pub mod folder;
 pub mod settings;

--- a/database/src/models/post.rs
+++ b/database/src/models/post.rs
@@ -1,5 +1,6 @@
 use crate::{
     DatabasePool,
+    models::expired::{ExpiredPost, ExpiredPostInsertForm},
     newtypes::{FeedId, FolderId, PostId},
     schema::{
         feeds,
@@ -8,7 +9,7 @@ use crate::{
 };
 use chrono::{DateTime, Duration, Utc};
 use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
+use diesel_async::{AsyncConnection, RunQueryDsl};
 use feed_rs::model::Entry;
 use serde::{Deserialize, Serialize};
 use wyrm_utils::{error::WyrmError, result::WyrmResult};
@@ -84,6 +85,10 @@ impl Post {
     /// that already exist and never creates duplicates. The returned count is
     /// the number of rows actually inserted (conflicts excluded).
     ///
+    /// Forms whose `(feed_id, url)` is recorded in `expired_posts` are also
+    /// dropped before the insert, so posts expired (deleted) by the expiry  
+    /// can't come back (see [`ExpiredPost`]).
+    ///
     /// Because all rows share one statement, error granularity differs from
     /// inserting row-by-row: a genuine row-level failure (a constraint the
     /// database cannot skip, e.g. a NOT NULL / CHECK / foreign-key violation)
@@ -92,15 +97,26 @@ impl Post {
     /// the conflict clause above.
     ///
     /// An empty `forms` is a no-op and returns `Ok(0)` without touching the
-    /// pool.
+    /// pool. A batch that becomes empty after the expired-posts filter is
+    /// also fine.
     pub async fn create_many(
         pool: &DatabasePool,
-        forms: Vec<PostInsertForm>,
+        mut forms: Vec<PostInsertForm>,
     ) -> WyrmResult<Vec<Post>> {
         if forms.is_empty() {
             return Ok(vec![]);
         }
         let mut conn = pool.get().await?;
+
+        // Filter out anything recorded in the expired_posts table before inserting.
+        let feed_ids = forms.iter().map(|f| f.feed_id).collect();
+        let urls = forms.iter().filter_map(|f| f.url.as_deref()).collect();
+        let expired = ExpiredPost::matching(&conn, feed_ids, urls).await?;
+        forms.retain(|f| match &f.url {
+            Some(url) => !expired.contains(&(f.feed_id, url.clone())),
+            None => true,
+        });
+
         diesel::insert_into(posts::table)
             .values(&forms)
             .on_conflict((posts::feed_id, posts::url))
@@ -188,33 +204,43 @@ impl Post {
     }
 
     pub async fn expire_read(pool: &DatabasePool, days: i32) -> WyrmResult<usize> {
-        let mut conn = pool.get().await?;
-        let cutoff = Utc::now() - Duration::days(days as i64);
-        diesel::delete(
-            posts::table
-                .filter(posts::is_read.eq(true))
-                .filter(posts::is_archived.eq(false))
-                .filter(posts::bookmarked.eq(false))
-                .filter(posts::created_at.lt(cutoff)),
-        )
-        .execute(&mut conn)
-        .await
-        .map_err(WyrmError::from)
+        Self::expire(pool, days, true).await
     }
 
     pub async fn expire_unread(pool: &DatabasePool, days: i32) -> WyrmResult<usize> {
+        Self::expire(pool, days, false).await
+    }
+    /// Deletes read or unread posts older than `days` and tombstones their urls
+    /// in `expired_posts` in the same transaction, so a later poll can't
+    /// re-insert them while they're still listed in the upstream feed.
+    async fn expire(pool: &DatabasePool, days: i32, is_read: bool) -> WyrmResult<usize> {
         let mut conn = pool.get().await?;
+        let conn = &mut *conn;
+
         let cutoff = Utc::now() - Duration::days(days as i64);
-        diesel::delete(
-            posts::table
-                .filter(posts::is_read.eq(false))
-                .filter(posts::is_archived.eq(false))
-                .filter(posts::bookmarked.eq(false))
-                .filter(posts::created_at.lt(cutoff)),
-        )
-        .execute(&mut conn)
+
+        conn.transaction(async |conn| {
+            let deleted: Vec<(FeedId, Option<String>)> = diesel::delete(
+                posts::table
+                    .filter(posts::is_read.eq(is_read))
+                    .filter(posts::is_archived.eq(false))
+                    .filter(posts::bookmarked.eq(false))
+                    .filter(posts::created_at.lt(cutoff)),
+            )
+            .returning((posts::feed_id, posts::url))
+            .get_results(conn)
+            .await?;
+
+            let count = deleted.len();
+            let forms: Vec<ExpiredPostInsertForm> = deleted
+                .into_iter()
+                .filter_map(|(feed_id, url)| url.map(|url| ExpiredPostInsertForm { feed_id, url }))
+                .collect();
+            ExpiredPost::create_many_on(conn, forms).await?;
+
+            Ok::<usize, WyrmError>(count)
+        })
         .await
-        .map_err(WyrmError::from)
     }
 }
 
@@ -616,5 +642,82 @@ mod tests {
         assert_eq!(form.authors.as_deref(), Some("Test Author"));
         assert_eq!(form.description.as_deref(), Some("Test description."));
         assert_eq!(form.content, None);
+    }
+
+    /// One test covers both sweeps and the refetch: the sweeps scan the whole
+    /// (shared) test database, so parallel tests with backdated posts would
+    /// expire each other's fixtures.
+    #[tokio::test]
+    async fn expire_records_expired_posts_and_blocks_refetch() {
+        let pool = setup_test_db().await;
+        let feed = test_feed!(&pool);
+
+        // Look up the id a url got on insert.
+        macro_rules! post_id {
+            ($url:expr) => {{
+                let mut conn = pool.get().await.expect("should get conn");
+                posts::table
+                    .filter(posts::feed_id.eq(feed.id))
+                    .filter(posts::url.eq($url))
+                    .select(posts::id)
+                    .first::<PostId>(&mut conn)
+                    .await
+                    .expect("post should exist")
+            }};
+        }
+
+        // Three posts old enough to expire: one read, one unread, and one
+        // read + bookmarked that must survive the sweep.
+        let read_url = format!("https://example.com/post/{}", unique!());
+        let unread_url = format!("https://example.com/post/{}", unique!());
+        let kept_url = format!("https://example.com/post/{}", unique!());
+        for url in [&read_url, &unread_url, &kept_url] {
+            let mut form = post_form!(feed.id, url);
+            form.created_at = Some(Utc::now() - Duration::days(10));
+            Post::create(&pool, form).await.expect("should create post");
+        }
+        let read_id = post_id!(&read_url);
+        let kept_id = post_id!(&kept_url);
+        for (id, bookmarked) in [(read_id, None), (kept_id, Some(true))] {
+            Post::update(
+                &pool,
+                PostUpdateForm {
+                    id,
+                    bookmarked,
+                    is_read: Some(true),
+                },
+            )
+            .await
+            .expect("should mark post read");
+        }
+
+        // Other tests share the database, so rows besides ours may expire:
+        // assert on our posts, not exact counts.
+        assert!(Post::expire_read(&pool, 5).await.unwrap() >= 1);
+        assert!(Post::expire_unread(&pool, 5).await.unwrap() >= 1);
+        assert!(Post::get(&pool, read_id).await.is_err());
+        assert!(Post::get(&pool, kept_id).await.is_ok());
+        assert_eq!(Post::unread_count(&pool, feed.id).await.unwrap(), 0);
+
+        // Re-fetch: the expired urls must stay gone — their rows are deleted,
+        // so only the expired_posts filter can block them — while a fresh url
+        // in the same batch inserts normally.
+        let fresh_url = format!("https://example.com/post/{}", unique!());
+        let inserted = Post::create_many(
+            &pool,
+            vec![
+                post_form!(feed.id, &read_url),
+                post_form!(feed.id, &unread_url),
+                post_form!(feed.id, &fresh_url),
+            ],
+        )
+        .await
+        .expect("create_many should succeed");
+        assert_eq!(inserted.len(), 1);
+        assert_eq!(inserted[0].url.as_deref(), Some(fresh_url.as_str()));
+
+        Feed::delete(&pool, feed.id)
+            .await
+            .expect("should delete feed");
     }
 }

--- a/database/src/schema.rs
+++ b/database/src/schema.rs
@@ -11,6 +11,14 @@ pub mod sql_types {
 }
 
 diesel::table! {
+    expired_posts (feed_id, url) {
+        feed_id -> Int4,
+        url -> Text,
+        expired_at -> Timestamptz,
+    }
+}
+
+diesel::table! {
     feed_icons (feed_id) {
         feed_id -> Int4,
         data -> Nullable<Bytea>,
@@ -110,6 +118,7 @@ diesel::table! {
     }
 }
 
+diesel::joinable!(expired_posts -> feeds (feed_id));
 diesel::joinable!(feed_icons -> feeds (feed_id));
 diesel::joinable!(feed_webhooks -> feeds (feed_id));
 diesel::joinable!(feed_webhooks -> webhooks (webhook_id));
@@ -117,6 +126,7 @@ diesel::joinable!(feeds -> folders (folder_id));
 diesel::joinable!(posts -> feeds (feed_id));
 
 diesel::allow_tables_to_appear_in_same_query!(
+    expired_posts,
     feed_icons,
     feed_webhooks,
     feeds,

--- a/migrations/2026-07-13-030052-0000_add_expired_posts_table/down.sql
+++ b/migrations/2026-07-13-030052-0000_add_expired_posts_table/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE expired_posts;

--- a/migrations/2026-07-13-030052-0000_add_expired_posts_table/up.sql
+++ b/migrations/2026-07-13-030052-0000_add_expired_posts_table/up.sql
@@ -1,0 +1,9 @@
+-- History of expired (deleted) posts: the (feed_id, url) dedup constraint
+-- on posts forgets a post the moment its row is deleted, so any expired post
+-- still listed in the upstream feed would be re-inserted on the next poll.
+CREATE TABLE expired_posts (
+    feed_id    INTEGER NOT NULL REFERENCES feeds(id) ON DELETE CASCADE,
+    url        TEXT NOT NULL,
+    expired_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (feed_id, url)
+);

--- a/web/src/components/settings/General.tsx
+++ b/web/src/components/settings/General.tsx
@@ -60,15 +60,16 @@ function GeneralForm({ initial }: { initial: Settings }) {
         <input type="number" min={1} value={pageSize} onChange={(e) => setPageSize(e.target.value)} required />
       </div>
       <div className="settings-field">
-        <label>Expire read posts after</label>
-        <input type="number" min={1} placeholder="Never expire" value={expireReadAfterDays} onChange={(e) => setExpireReadAfterDays(e.target.value)} />
+        <label>Delete read posts after</label>
+        <input type="number" min={1} placeholder="Never" value={expireReadAfterDays} onChange={(e) => setExpireReadAfterDays(e.target.value)} />
         <label>days</label>
       </div>
       <div className="settings-field">
-        <label>Expire unread posts after</label>
-        <input type="number" min={1} placeholder="Never expire" value={expireUnreadAfterDays} onChange={(e) => setExpireUnreadAfterDays(e.target.value)} />
+        <label>Delete unread posts after</label>
+        <input type="number" min={1} placeholder="Never" value={expireUnreadAfterDays} onChange={(e) => setExpireUnreadAfterDays(e.target.value)} />
         <label>days</label>
       </div>
+      <p className="settings-hint">Read Later and archived posts are never deleted.</p>
 
       <h2 className="settings-section-title">Polling</h2>
       <div className="settings-field">


### PR DESCRIPTION
Related to https://github.com/kryoseu/WyrmRSS/issues/99

0.25.0 introduced a regression whereby auto-deleted read/unread posts are re-imported as unread if the upstream feed still advertises them.

This change adds a "expired_posts" table to keep record of deleted posts. The dedup is on (feed_id, url), so a post with same feed_id and url is not re-inserted into the posts table.