### PR TITLE
fix: upgrade react-router to 8.3.0, resolving CVE-2026-22030

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -14,9 +14,9 @@
     "@tanstack/react-virtual": "^3.14.8",
     "dompurify": "^3.4.12",
     "react": "^19.2.8",
-    "react-dom": "^19.2.7",
+    "react-dom": "^19.2.8",
     "react-icons": "^5.7.0",
-    "react-router-dom": "^7.18.1",
+    "react-router": "^8.3.0",
     "react-youtube": "^10.1.0"
   },
   "devDependencies": {

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -12,8 +12,13 @@ importers:
         specifier: ^5.101.4
         version: 5.101.4(react@19.2.8)
       '@tanstack/react-virtual':
+<<<<<<< HEAD
         specifier: ^3.14.8
         version: 3.14.8(react-dom@19.2.7(react@19.2.8))(react@19.2.8)
+=======
+        specifier: ^3.14.6
+        version: 3.14.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+>>>>>>> b49690b (fix: upgrade react-router to 8.3.0, resolving CVE-2026-22030)
       dompurify:
         specifier: ^3.4.12
         version: 3.4.12
@@ -21,14 +26,14 @@ importers:
         specifier: ^19.2.8
         version: 19.2.8
       react-dom:
-        specifier: ^19.2.7
-        version: 19.2.7(react@19.2.8)
+        specifier: ^19.2.8
+        version: 19.2.8(react@19.2.8)
       react-icons:
         specifier: ^5.7.0
         version: 5.7.0(react@19.2.8)
-      react-router-dom:
-        specifier: ^7.18.1
-        version: 7.18.1(react-dom@19.2.7(react@19.2.8))(react@19.2.8)
+      react-router:
+        specifier: ^8.3.0
+        version: 8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react-youtube:
         specifier: ^10.1.0
         version: 10.1.0(react@19.2.8)
@@ -483,9 +488,8 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
-  cookie@1.1.1:
-    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
-    engines: {node: '>=18'}
+  cookie-es@3.1.1:
+    resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -849,10 +853,10 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  react-dom@19.2.7:
-    resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
+  react-dom@19.2.8:
+    resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
     peerDependencies:
-      react: ^19.2.7
+      react: ^19.2.8
 
   react-icons@5.7.0:
     resolution: {integrity: sha512-LBLy340Rzqy6+/yVhZKT3B/QpP1BZaesGqasf09HPOBzRarcDIFH0WwXlXQfE7q7ipxK4MSiC5DIBWURCny6fw==}
@@ -862,19 +866,12 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
-  react-router-dom@7.18.1:
-    resolution: {integrity: sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==}
-    engines: {node: '>=20.0.0'}
+  react-router@8.3.0:
+    resolution: {integrity: sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==}
+    engines: {node: '>=22.22.0'}
     peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
-
-  react-router@7.18.1:
-    resolution: {integrity: sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
+      react: '>=19.2.7'
+      react-dom: '>=19.2.7'
     peerDependenciesMeta:
       react-dom:
         optional: true
@@ -905,9 +902,6 @@ packages:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
-
-  set-cookie-parser@2.7.2:
-    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -1290,11 +1284,15 @@ snapshots:
       '@tanstack/query-core': 5.101.4
       react: 19.2.8
 
+<<<<<<< HEAD
   '@tanstack/react-virtual@3.14.8(react-dom@19.2.7(react@19.2.8))(react@19.2.8)':
+=======
+  '@tanstack/react-virtual@3.14.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+>>>>>>> b49690b (fix: upgrade react-router to 8.3.0, resolving CVE-2026-22030)
     dependencies:
       '@tanstack/virtual-core': 3.17.6
       react: 19.2.8
-      react-dom: 19.2.7(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
 
   '@tanstack/virtual-core@3.17.6': {}
 
@@ -1453,7 +1451,7 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  cookie@1.1.1: {}
+  cookie-es@3.1.1: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -1762,7 +1760,7 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  react-dom@19.2.7(react@19.2.8):
+  react-dom@19.2.8(react@19.2.8):
     dependencies:
       react: 19.2.8
       scheduler: 0.27.0
@@ -1773,19 +1771,12 @@ snapshots:
 
   react-is@16.13.1: {}
 
-  react-router-dom@7.18.1(react-dom@19.2.7(react@19.2.8))(react@19.2.8):
+  react-router@8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
+      cookie-es: 3.1.1
       react: 19.2.8
-      react-dom: 19.2.7(react@19.2.8)
-      react-router: 7.18.1(react-dom@19.2.7(react@19.2.8))(react@19.2.8)
-
-  react-router@7.18.1(react-dom@19.2.7(react@19.2.8))(react@19.2.8):
-    dependencies:
-      cookie: 1.1.1
-      react: 19.2.8
-      set-cookie-parser: 2.7.2
     optionalDependencies:
-      react-dom: 19.2.7(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
 
   react-youtube@10.1.0(react@19.2.8):
     dependencies:
@@ -1824,8 +1815,6 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.8.5: {}
-
-  set-cookie-parser@2.7.2: {}
 
   shebang-command@2.0.0:
     dependencies:

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
+import { BrowserRouter, Navigate, Route, Routes } from "react-router";
 import "./App.css";
 import { ApiKeyGate } from "./components/ApiKeyGate";
 import { ArchiveList } from "./components/ArchiveList";

--- a/web/src/components/ArchiveItem.tsx
+++ b/web/src/components/ArchiveItem.tsx
@@ -1,5 +1,5 @@
 import { memo } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { TbArchiveOff } from "react-icons/tb";
 import type { PostArchive } from "../types/PostArchive";
 import { useUnarchivePost } from "../hooks/usePostMutations";

--- a/web/src/components/ArchiveList.tsx
+++ b/web/src/components/ArchiveList.tsx
@@ -1,4 +1,4 @@
-import { useOutletContext, useParams } from "react-router-dom";
+import { useOutletContext, useParams } from "react-router";
 import { useArchivedPosts } from "../hooks/usePosts";
 import { useDebouncedSearch } from "../hooks/useDebouncedSearch";
 import { useOpenPostFromRoute } from "../hooks/useOpenPostFromRoute";

--- a/web/src/components/BookmarkedPostList.tsx
+++ b/web/src/components/BookmarkedPostList.tsx
@@ -1,4 +1,4 @@
-import { useOutletContext, useParams } from "react-router-dom";
+import { useOutletContext, useParams } from "react-router";
 import { useBookmarkedPosts } from "../hooks/usePosts";
 import { useFeeds } from "../hooks/useFeeds";
 import { useDebouncedSearch } from "../hooks/useDebouncedSearch";

--- a/web/src/components/FeedItem.tsx
+++ b/web/src/components/FeedItem.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { TbChecks, TbPencil, TbPlayerPause, TbPlayerPlay, TbX } from "react-icons/tb";
 import { useDeleteFeed, useSetFeedPaused } from "../hooks/useFeeds";
 import { useMarkRead } from "../hooks/usePostMutations";

--- a/web/src/components/FeedList.tsx
+++ b/web/src/components/FeedList.tsx
@@ -5,7 +5,7 @@ import { useFolders, useUpdateFolder } from "../hooks/useFolders";
 import { useMarkRead } from "../hooks/usePostMutations";
 import { FeedItem } from "./FeedItem";
 import { RowMenu } from "./RowMenu";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { AddFeedForm } from "./AddFeedForm";
 import { FolderForm } from "./FolderForm";
 import { renameErrorMessage } from "../api/folders";

--- a/web/src/components/PostItem.tsx
+++ b/web/src/components/PostItem.tsx
@@ -1,5 +1,5 @@
 import { memo } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { HiMail, HiMailOpen } from "react-icons/hi";
 import { TbArchive, TbArchiveOff, TbBookmark, TbBookmarkFilled } from "react-icons/tb";
 import type { Post } from "../types/Post";

--- a/web/src/components/PostList.tsx
+++ b/web/src/components/PostList.tsx
@@ -1,4 +1,4 @@
-import { useOutletContext, useParams } from "react-router-dom";
+import { useOutletContext, useParams } from "react-router";
 import { TbChecks, TbEye, TbEyeOff, TbRefresh } from "react-icons/tb";
 import { usePosts } from "../hooks/usePosts";
 import { useUnreadOnly } from "../hooks/useUnreadOnly";

--- a/web/src/components/SideMenu.tsx
+++ b/web/src/components/SideMenu.tsx
@@ -1,4 +1,4 @@
-import { NavLink } from "react-router-dom";
+import { NavLink } from "react-router";
 import { useTheme, PALETTES } from "../hooks/useTheme";
 import type { AccentKey } from "../hooks/useTheme";
 import { FeedList } from "./FeedList";

--- a/web/src/pages/AppLayout.tsx
+++ b/web/src/pages/AppLayout.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from "react-router-dom";
+import { Outlet } from "react-router";
 import { SideMenu } from "../components/SideMenu";
 
 export function AppLayout() {

--- a/web/src/pages/ReaderPage.tsx
+++ b/web/src/pages/ReaderPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef } from "react";
-import { Outlet, useLocation } from "react-router-dom";
+import { Outlet, useLocation } from "react-router";
 import { ArchiveReader } from "../components/ArchiveReader";
 import { PostReader } from "../components/PostReader";
 import type { PostId } from "../types/PostId";


### PR DESCRIPTION
react-router-dom no longer exists as of v8; react-router absorbed it and re-exports the DOM bindings (BrowserRouter, Link, etc.) from its root entrypoint. Updated all imports accordingly and bumped react-dom to 19.2.8 to match react, since v8's peer deps require matching exact versions.