### PR TITLE
Update docker.md to make wyrm-ui depend on wyrm-server

### DIFF
--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -61,6 +61,9 @@ services:
       # WYRM_API_KEY: "changeme"  # must match the server's WYRM_API_KEY
     ports:
       - 3000:3000
+    depends_on:
+      wyrm-server:
+        condition: service_healthy
     restart: unless-stopped
 volumes:
   wyrm_data:

--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -40,6 +40,11 @@ services:
       # WYRM_API_KEY: "changeme"  # set to protect the API
     ports:
       - 3001:3001
+    healthcheck:
+      test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/127.0.0.1/3001"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
     volumes:
       - /path/to/config:/app/config
     depends_on:


### PR DESCRIPTION
While trying out WyrmRSS locally (on a macOS device), I kept running into issues due to wyrm-server not being ready. I think making wyrm-ui depend on wyrm-server being ready is a reasonable change here, so thought I'd suggest it.

P.S. I'm looking to move to Wyrm from Yarr, so I appreciate the additional features.