### PR TITLE
fix: always show radar feeds regardless of unread count

### DIFF
--- a/web/src/components/RadarBoard.tsx
+++ b/web/src/components/RadarBoard.tsx
@@ -69,7 +69,7 @@ export function RadarBoard() {
   const { data: feeds, isLoading } = useFeeds();
 
   const cards = (feeds ?? [])
-    .filter((f) => f.display_mode === "radar" && f.unread_count > 0)
+    .filter((f) => f.display_mode === "radar")
     .sort((a, b) => b.unread_count - a.unread_count || a.title.localeCompare(b.title));
 
   // cards is sorted by unread desc, and the threshold is monotone over that


### PR DESCRIPTION
When updating a feed's display mode to radar, the feed may not show on the radar board if it has no unread posts, which may leave the user wondering "why is my feed not showing up?".

This change makes it so that feeds always show on the radar board.